### PR TITLE
Use window.STATIC_PREFIX to fix font loading error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "katex": "^0.16.2",
         "mathjs": "^11.2.1",
+        "path-browserify": "^1.0.1",
         "sirv-cli": "^2.0.2",
         "stats.js": "^0.17.0",
         "svelte-preprocess": "^4.10.7",
@@ -4048,6 +4049,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -8268,6 +8274,11 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "path-exists": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "katex": "^0.16.2",
     "mathjs": "^11.2.1",
+    "path-browserify": "^1.0.1",
     "sirv-cli": "^2.0.2",
     "stats.js": "^0.17.0",
     "svelte-preprocess": "^4.10.7",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 /* jshint esversion: 6 */
 
 import * as THREE from 'three';
+import path from 'path-browserify';
 
 export function marchingSquares({
     f,
@@ -1147,14 +1148,20 @@ function labelAxes({
     scene,
     gridMax = 1,
     gridStep = 0.1,
-    fontFile = "../fonts/P052_Italic.json",
+    fontFile = './fonts/P052_Italic.json',
     textMaterial = new THREE.MeshBasicMaterial({ color: 0x000000 }),
     axesText = [],
     render = undefined,
 } = {}, fontLoader, TextGeometry) {
+    let fontUrl = fontFile;
+    // Use static prefix from Django if present
+    if (window.STATIC_PREFIX) {
+        fontUrl = path.join(window.STATIC_PREFIX, fontUrl);
+    }
+
     const font = fontLoader.load(
         // resource URL
-        fontFile,
+        fontUrl,
         function (font) {
             // clear out the old
             for (let index = 0; index < axesText.length; index++) {
@@ -1222,8 +1229,8 @@ function labelAxes({
         },
 
         // onError callback
-        function () {
-            console.log("An error happened");
+        function (e) {
+            console.log('Font loading error:', e);
         }
     );
     return [axesText, font];


### PR DESCRIPTION
This fixes a problem when used with the django back-end.

Related to this PR:
https://github.com/ccnmtl/mathplayground_django/pull/6