### PR TITLE
Add basic poll rendering from localstorage

### DIFF
--- a/src/PollRoom.svelte
+++ b/src/PollRoom.svelte
@@ -1,7 +1,29 @@
 <script>
+    import {getPollId} from './polls.js';
+    import {polls} from './stores.js';
+
+    const pollId = getPollId(window.location.pathname);
+    const poll = $polls.find(x => x.id === pollId);
 </script>
 
-<h1>Poll</h1>
+<h1>Poll {pollId}</h1>
+{#if !poll}
+    <p>Poll {pollId} is not defined!</p>
+{/if}
+
 <p>
-    Poll
+    Prompt:
+    {poll && poll.prompt}
 </p>
+
+<p>
+    Choices:
+</p>
+
+{#if poll}
+    <ul>
+        {#each poll.choices as choice}
+            <li>{choice}</li>
+        {/each}
+    </ul>
+{/if}

--- a/src/polls.js
+++ b/src/polls.js
@@ -1,6 +1,17 @@
+import {forceNumber} from './utils.js';
+
 const newPollId = function(polls) {
     return polls.length ? Math.max(...polls.map(p => p.id)) + 1 : 1;
 }
+
+const getPollId = function(urlpath) {
+    let m = urlpath.match(/^\/?polls\/(\d+)\/?/);
+    if (m && m.length > 1) {
+        return forceNumber(m[1]);
+    }
+
+    return null;
+};
 
 /**
  * makePoll
@@ -53,5 +64,6 @@ const makeSocket = function(roomName) {
 };
 
 export {
+    getPollId,
     makePoll, makeSocket
 };

--- a/src/stores.js
+++ b/src/stores.js
@@ -23,7 +23,7 @@ export const initialPolls = [
     }
 ];
 
-let polls = localStore('polls', initialPolls);
+const polls = localStore('polls', initialPolls);
 
 export {
     polls

--- a/src/utils.js
+++ b/src/utils.js
@@ -1625,6 +1625,17 @@ function isDependentOn(node, x) {
     return node.filter((node) => node.isSymbolNode && node.name === x).length > 0;
 }
 
+/**
+ * Cast the given input into a number, in a forgiving way.
+ */
+const forceNumber = function(n) {
+    n = Number(n);
+    if (isNaN(n) || typeof n === 'undefined') {
+        n = 0;
+    }
+    return n;
+};
+
 export {
     ArrowBufferGeometry,
     ParametricCurve,
@@ -1643,4 +1654,5 @@ export {
     nextHue,
     makeHSLColor,
     blockGeometry,
+    forceNumber
 };


### PR DESCRIPTION
Use a path like `/polls/1/` to designate the poll id. Look up that ID in localstorage.

For now, I've hardcoded a few initial polls. Next steps:
* Make the polls array editable by instructor
* Propagate changes to the polls array via websockets?

Currently, there is no notion of instructor/student in the application. This is fine, but we will need to have some mechanism here for giving an "instructor" view of the poll, which will look very different from the students' view. The thing is, we're designing this application without a database, at least to start. We can think creatively on how to solve this. And of course, we can always end up using a database at the end of the day, if necessary.

![Screenshot_2022-10-09_17-01-24](https://user-images.githubusercontent.com/59292/194779301-af387bfb-54a2-4bc4-b1ec-24c5477d6ef8.png)
