### PR TITLE
Implement new URL joiner based on the URL api

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "katex": "^0.16.2",
     "mathjs": "^11.2.1",
-    "path-browserify": "^1.0.1",
     "sirv-cli": "^2.0.2",
     "stats.js": "^0.17.0",
     "svelte-preprocess": "^4.10.7",

--- a/src/Level.svelte
+++ b/src/Level.svelte
@@ -1,6 +1,5 @@
 <script>
     import { onDestroy } from "svelte";
-    import path from 'path-browserify';
     import M from "./M.svelte";
 
     import * as THREE from "three";
@@ -10,7 +9,11 @@
     const config = {};
     const math = create(all, config);
 
-    import { marchingCubes, ArrowBufferGeometry } from "./utils.js";
+    import {
+        joinUrl,
+        marchingCubes,
+        ArrowBufferGeometry
+    } from "./utils.js";
 
     // const config = {};
     // const math = create(all, config);
@@ -75,7 +78,7 @@
 
     let workerUrl = './levelWorker.js';
     if (window.STATIC_PREFIX) {
-        workerUrl = path.join(window.STATIC_PREFIX, workerUrl);
+        workerUrl = joinUrl(window.STATIC_PREFIX, workerUrl);
     }
     const worker = new Worker(workerUrl, {
         type: "classic",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,26 @@
 /* jshint esversion: 6 */
 
 import * as THREE from 'three';
-import path from 'path-browserify';
+
+/**
+ * Given a URL base and a path, return the two combined.
+ *
+ * This should work with both local, relative paths and absolute URIs.
+ */
+const joinUrl = function(base, path) {
+    let url = {};
+
+    try {
+        url = new URL(path, base);
+    } catch (e) {
+        url = new URL(
+            base.substring(1) +
+                path.substring(1),
+            document.baseURI)
+    }
+
+    return url.href;
+}
 
 export function marchingSquares({
     f,
@@ -1156,7 +1175,7 @@ function labelAxes({
     let fontUrl = fontFile;
     // Use static prefix from Django if present
     if (window.STATIC_PREFIX) {
-        fontUrl = path.join(window.STATIC_PREFIX, fontUrl);
+        fontUrl = joinUrl(window.STATIC_PREFIX, fontFile)
     }
 
     const font = fontLoader.load(
@@ -1644,6 +1663,7 @@ const forceNumber = function(n) {
 };
 
 export {
+    joinUrl,
     ArrowBufferGeometry,
     ParametricCurve,
     drawGrid,

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,5 +1,18 @@
 import assert from 'assert';
-import {gcd} from '../src/utils.js';
+import {
+    joinUrl,
+    gcd
+} from '../src/utils.js';
+
+describe('joinUrl', function() {
+    it('joins two URLs',
+       function() {
+           assert.equal(
+               joinUrl('https://example.org/', './image/path.png'),
+               'https://example.org/image/path.png'
+           );
+       });
+});
 
 describe('gcd', function() {
     it('should return the greatest common divisor of two numbers',


### PR DESCRIPTION
Node's `path` api is really meant to be used with local filesystem paths and the browserified version of this may have issues.

Try using this instead, to fix our deployment bug: https://developer.mozilla.org/en-US/docs/Web/API/URL/URL