### PR TITLE
Test out cross-origin web worker workaround

### DIFF
--- a/src/Level.svelte
+++ b/src/Level.svelte
@@ -11,6 +11,7 @@
 
     import {
         joinUrl,
+        createWorker,
         marchingCubes,
         ArrowBufferGeometry
     } from "./utils.js";
@@ -80,10 +81,7 @@
     if (window.STATIC_PREFIX) {
         workerUrl = joinUrl(window.STATIC_PREFIX, workerUrl);
     }
-    const worker = new Worker(workerUrl, {
-        type: "classic",
-    });
-    console.log(worker);
+    const worker = createWorker(workerUrl);
 
     // worker.postMessage({ hello: "World!" });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,44 @@ const joinUrl = function(base, path) {
     }
 
     return url.href;
-}
+};
+
+/**
+ * Web worker constructor that works in both same-origin and
+ * cross-domain scenarios.
+ *
+ * https://benohead.com/blog/2017/12/06/cross-domain-cross-browser-web-workers/
+ */
+const createWorker = function(workerUrl) {
+    let worker = null;
+    try {
+        worker = new Worker(workerUrl);
+    } catch (e) {
+        try {
+            let blob;
+            try {
+                blob = new Blob(
+                    ["importScripts('" + workerUrl + "');"], {
+                        "type": 'application/javascript'
+                    });
+            } catch (e1) {
+                let blobBuilder = new (
+                    window.BlobBuilder ||
+                        window.WebKitBlobBuilder ||
+                        window.MozBlobBuilder)();
+                blobBuilder.append("importScripts('" + workerUrl + "');");
+                blob = blobBuilder.getBlob('application/javascript');
+            }
+            let url = window.URL || window.webkitURL;
+            let blobUrl = url.createObjectURL(blob);
+            worker = new Worker(blobUrl);
+        } catch (e2) {
+            // if it still fails, there is nothing much we can do
+            console.error('Failed to load worker:', e2);
+        }
+    }
+    return worker;
+};
 
 export function marchingSquares({
     f,
@@ -1669,6 +1706,7 @@ const forceNumber = function(n) {
 
 export {
     joinUrl,
+    createWorker,
     ArrowBufferGeometry,
     ParametricCurve,
     drawGrid,


### PR DESCRIPTION
Now that the levelWorker.js url path is finally correct, we get this CORS error:
```
bundle.js:21 Uncaught (in promise) DOMException: Failed to construct
'Worker': Script at
'https://ctl-mathplayground-static-prod.s3.amazonaws.com/media/mathplayground/levelWorker.js'
cannot be accessed from origin
'https://mathplayground.ctl.columbia.edu'.
```

Turns out you can't load a web worker from a different domain (our S3 bucket), but there is a way to work around this.
https://benohead.com/blog/2017/12/06/cross-domain-cross-browser-web-workers/

I can't confirm that this works yet, but it's working locally, let's test this on production with these changes.