### PR TITLE
url joiner: use window.location.origin instead of baseURI

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -21,7 +21,7 @@ const joinUrl = function(base, path) {
         url = new URL(
             base.substring(1) +
                 path.substring(1),
-            document.baseURI)
+            window.location.origin)
     }
 
     return url.href;


### PR DESCRIPTION
The origin excludes the URL path, making this work properly when at different URL routes in the application.