### PR TITLE
Fix bootstrap container class

### DIFF
--- a/media/mathplayground/global.css
+++ b/media/mathplayground/global.css
@@ -96,7 +96,7 @@ body,
     width: 3rem;
 }
 
-.container {
+.3demos-container {
     display: grid;
 
     grid-template-columns: 1fr auto 1fr;

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -468,7 +468,7 @@
         <ObjHeader bind:hidden bind:onClose />
     </div>
     <div {hidden}>
-        <div class="container">
+        <div class="3demos-container container">
             {#each ['x', 'y', 'z'] as name}
                 <span class="box-1"><M size="sm">{name}(t) =</M></span>
                 <InputChecker

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -405,7 +405,7 @@
         <ObjHeader bind:hidden bind:onClose />
     </div>
     <div {hidden}>
-        <div class="container">
+        <div class="3demos-container container">
             {#each ['p', 'q', 'r'] as name}
                 <span class="box-1"
                     ><M size="sm">{name.toUpperCase()}(t) =</M></span

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -906,7 +906,7 @@
         <ObjHeader bind:hidden bind:onClose />
     </div>
     <div {hidden}>
-        <div class="container">
+        <div class="3demos-container container">
             <span class="box-1">
                 <M size="sm">f(x,y[,t]) =</M>
             </span>

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -420,7 +420,7 @@
         <ObjHeader bind:hidden bind:onClose />
     </div>
     <div {hidden}>
-        <div class="container">
+        <div class="3demos-container container">
             <span class="box-1"><M size="sm">g(x,y,z) =</M></span>
             <InputChecker
                 value={params['g']}

--- a/media/src/objects/ParSurf.svelte
+++ b/media/src/objects/ParSurf.svelte
@@ -571,7 +571,7 @@
         <ObjHeader bind:hidden bind:onClose />
     </div>
     <div {hidden}>
-        <div class="container">
+        <div class="3demos-container container">
             {#each ['x', 'y', 'z'] as name}
                 <span class="box-1"><M size="sm">{name}(u,v) =</M></span>
                 <InputChecker

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -249,7 +249,7 @@
         <ObjHeader bind:hidden bind:onClose />
     </div>
     <div {hidden}>
-        <div class="container">
+        <div class="3demos-container container">
             {#each ['a', 'b', 'c', 'x', 'y', 'z'] as name}
                 {#if name === 'x'}
                     <span class="box-1">


### PR DESCRIPTION
We shouldn't overwrite `.container` styles as this breaks container usage in bootstrap, which we may want to use in some cases - e.g. laying out the menus in a more unified way:
https://getbootstrap.com/docs/5.3/layout/containers/