### PR TITLE
Fix bug where loading an animated scene displays low resolution

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -244,14 +244,6 @@
         const dt = (time - last) / 1000;
         last = time;
 
-        // for (const b of objects.filter((b) => b.animation)) {
-        //     if (typeof b.update === 'function') {
-        //         b.update(dt);
-        //     } else {
-        //         console.error('b.update is not callable', b);
-        //     }
-        // }
-
         // FYI, the linter doesn't like +=
         $tickTock = $tickTock + dt;
 
@@ -259,7 +251,7 @@
             scaleUpdate(dt);
         }
 
-        currentControls.update();
+        currentControls?.update();
         renderer.render(scene, currentCamera);
         if (debug) {
             stats.end();
@@ -298,7 +290,7 @@
             currentCamera.updateProjectionMatrix();
         }
 
-        currentControls.update();
+        currentControls?.update();
         renderer.render(scene, currentCamera);
     };
 
@@ -505,10 +497,14 @@
             stats.showPanel(1); // 0: fps, 1: ms, 2: mb, 3+: custom
             document.body.appendChild(stats.dom);
         }
-        // If any of the loaded objects are currently animating, call
-        // the animate() function.
+
+        // If any of the loaded objects are currently animating, start
+        // animation.
         if (objects.some((b) => b.animation)) {
-            animate();
+            // Do initial render to set canvas size correctly.
+            render();
+            // Start animation
+            animateIfNotAnimating();
         }
 
         renderer.domElement.addEventListener('pointermove', (e) =>
@@ -1055,14 +1051,7 @@
                                         {params}
                                         bind:color
                                         bind:animation
-                                        on:animate={(e) => {
-                                            console.log(
-                                                'vect anim',
-                                                animation,
-                                                e
-                                            );
-                                            animateIfNotAnimating();
-                                        }}
+                                        on:animate={animateIfNotAnimating}
                                         selected={selectedObject === uuid}
                                         on:click={selectObject(uuid)}
                                         on:keydown={altDown}


### PR DESCRIPTION
Closes #405

Without the initial `render()` call, the `<canvas>` element was getting a very low default size (300px), but still rendering the scene as well as it could. So, this is why it looked like my favorite space simulation game for MS-DOS: Noctis http://mooses.nl/nice/about/

There were other issues at play here as well, like `currentControls` being undefined, initially.