### PR TITLE
Refactor alt key handler

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -50,6 +50,7 @@
         labelAxes,
         makeHSLColor,
         convertToURLParams,
+        modFloor
     } from './utils';
     import {
         makeObject,
@@ -575,45 +576,41 @@
 
     const altDown = (e) => {
         if (e.altKey) {
-            e.preventDefault();
-            let i = 0;
-            if (e.code === 'Space') {
-                shadeUp = !shadeUp;
-            } else if (objects.length > 0) {
-                if (!selectedObject) {
-                    switch (e.code) {
-                        case 'BracketRight':
-                            selectedObject = objects[objects.length - 1].uuid;
-                            break;
-                        case 'BracketLeft':
-                            selectedObject = objects[0].uuid;
-                            break;
+            switch (e.code) {
+                case 'Space':
+                    e.preventDefault();
+                    shadeUp = !shadeUp;
+                    break;
+                case 'BracketRight':
+                    e.preventDefault();
+                    if (!objects) {
+                        return;
                     }
-                } else {
-                    while (
-                        i < objects.length &&
-                        objects[i].uuid !== selectedObject
-                    ) {
-                        i++;
+
+                    if (!selectedObject) {
+                        selectedObject = objects[objects.length - 1].uuid;
+                    } else {
+                        const selectedIndex = objects.map((x) => x.uuid).indexOf(
+                            selectedObject);
+                        const newIdx = modFloor(selectedIndex - 1, objects.length);
+                        selectedObject = objects[newIdx].uuid;
                     }
-                    switch (e.code) {
-                        case 'BracketRight':
-                            if (i === 0) {
-                                selectedObject =
-                                    objects[objects.length - 1].uuid;
-                                break;
-                            }
-                            selectedObject = objects[i - 1].uuid;
-                            break;
-                        case 'BracketLeft':
-                            if (i > objects.length - 2) {
-                                selectedObject = objects[0].uuid;
-                                break;
-                            }
-                            selectedObject = objects[i + 1].uuid;
-                            break;
+                    break;
+                case 'BracketLeft':
+                    e.preventDefault();
+                    if (!objects) {
+                        return;
                     }
-                }
+
+                    if (!selectedObject) {
+                        selectedObject = objects[0].uuid;
+                    } else {
+                        const selectedIndex = objects.map((x) => x.uuid).indexOf(
+                            selectedObject);
+                        const newIdx = modFloor(selectedIndex + 1, objects.length);
+                        selectedObject = objects[newIdx].uuid;
+                    }
+                    break;
             }
         }
     };

--- a/media/src/utils.js
+++ b/media/src/utils.js
@@ -1708,6 +1708,11 @@ function checksum(s)
   return (chk & 0xffffffff).toString(16);
 }
 
+// https://stackoverflow.com/a/43827557/173630
+const modFloor = function(a, n) {
+    return ((a % n) + n) % n;
+};
+
 export {
     joinUrl,
     getRoomUrl,
@@ -1731,5 +1736,6 @@ export {
     blockGeometry,
     forceNumber,
     querySelectorIncludesText,
-    checksum
+    checksum,
+    modFloor
 };


### PR DESCRIPTION
The main part here is putting `e.preventDefault()` in the specific key handlers. The alt key is used by many window managers and browsers, and we don't need to override all that behavior here: e.g. I use alt+number to switch browser tabs.