### PR TITLE
Colormaps for surfaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,4 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+quote_type = single

--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -18,7 +18,7 @@
 
     // import components
     import M from './M.svelte';
-    import ParSurf from './objects/ParSurf.svelte';
+    import Surface from './objects/Surface.svelte';
     import Level from './objects/Level.svelte';
     import Curve from './objects/Curve.svelte';
     import Field from './objects/Field.svelte';
@@ -34,7 +34,7 @@
         graph: Function,
         curve: Curve,
         level: Level,
-        parsurf: ParSurf,
+        surface: Surface,
     };
 
     import Stats from 'stats.js';
@@ -918,7 +918,7 @@
                                         on:click={() =>
                                             (objects = makeObject(
                                                 null,
-                                                'parsurf',
+                                                'surface',
                                                 {
                                                     a: '0',
                                                     b: '2*pi',

--- a/media/src/form-components/PlayButtons.svelte
+++ b/media/src/form-components/PlayButtons.svelte
@@ -2,7 +2,7 @@
     import { createEventDispatcher } from 'svelte';
 
     const dispatch = createEventDispatcher();
-    export let className = 'play-buttons box-3';
+    export let className = 'play-buttons box-2';
     export let animation = false;
 </script>
 

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -1,11 +1,11 @@
 <script>
-    import { onMount, onDestroy } from 'svelte';
-    import * as THREE from 'three';
-    import { create, all } from 'mathjs';
+    import { onMount, onDestroy } from "svelte";
+    import * as THREE from "three";
+    import { create, all } from "mathjs";
     // import { beforeUpdate } from 'svelte';
 
-    import M from '../M.svelte';
-    import ObjHeader from '../ObjHeader.svelte';
+    import M from "../M.svelte";
+    import ObjHeader from "../ObjHeader.svelte";
 
     const config = {};
     const math = create(all, config);
@@ -17,8 +17,8 @@
         // marchingCubes,
         checksum,
         ParametricGeometry,
-    } from '../utils.js';
-    import InputChecker from '../form-components/InputChecker.svelte';
+    } from "../utils.js";
+    import InputChecker from "../form-components/InputChecker.svelte";
     // import ObjectParamInput from '../form-components/ObjectParamInput.svelte';
 
     export let uuid;
@@ -26,15 +26,15 @@
     export let onDestroyObject = function () {};
 
     export let params = {
-        a: '-2',
-        b: '2',
-        c: '-2',
-        d: '1 + sin(pi*u)/2',
-        x: 'u',
-        y: 'v',
-        z: '1 - sin(u^2 - v^2)/2',
+        a: "-2",
+        b: "2",
+        c: "-2",
+        d: "1 + sin(pi*u)/2",
+        x: "u",
+        y: "v",
+        z: "1 - sin(u^2 - v^2)/2",
     };
-    export let color = '#3232ff';
+    export let color = "#3232ff";
     let rNum = 10;
     let cNum = 10;
     let nX = 60;
@@ -68,13 +68,13 @@
             const v = (C.evaluate({ u }) + D.evaluate({ u })) / 2;
             valuation = V.evaluate({ u, v });
         } catch (error) {
-            console.log('ParseError in evaluation.', error);
+            console.log("ParseError in evaluation.", error);
             return false;
         }
         if (Number.isFinite(valuation)) {
             return true;
         } else {
-            console.log('Evaluation error. Incomplete expression, maybe.');
+            console.log("Evaluation error. Incomplete expression, maybe.");
             return false;
         }
     };
@@ -333,8 +333,8 @@
         }
         scene.remove(surfaceMesh);
         scene.remove(tanFrame);
-        window.removeEventListener('keydown', shiftDown, false);
-        window.removeEventListener('keyup', shiftUp, false);
+        window.removeEventListener("keydown", shiftDown, false);
+        window.removeEventListener("keyup", shiftUp, false);
         render();
     });
 
@@ -436,13 +436,13 @@
             const arrow = arrows[key];
             let vec;
             switch (key) {
-                case 'u':
+                case "u":
                     vec = ru;
                     break;
-                case 'v':
+                case "v":
                     vec = rv;
                     break;
-                case 'n':
+                case "n":
                     vec = n;
                     break;
 
@@ -512,15 +512,15 @@
     const shiftDown = (e) => {
         if (shadeUp) {
             switch (e.key) {
-                case 'Backspace':
+                case "Backspace":
                     surfaceMesh.visible = !surfaceMesh.visible;
                     render();
                     break;
-                case 'Shift':
-                    window.addEventListener('mousemove', onMouseMove, false);
+                case "Shift":
+                    window.addEventListener("mousemove", onMouseMove, false);
                     tanFrame.visible = true;
                     break;
-                case 'c':
+                case "c":
                     controls.target.set(
                         point.position.x,
                         point.position.y,
@@ -528,11 +528,11 @@
                     );
                     render();
                     break;
-                case 't':
+                case "t":
                     tanFrame.visible = !tanFrame.visible;
                     render();
                     break;
-                case 'y':
+                case "y":
                     if (!planeShard.visible) {
                         tanFrame.visible = true;
                         planeShard.visible = true;
@@ -541,7 +541,7 @@
                     }
                     render();
                     break;
-                case 'n':
+                case "n":
                     if (!arrows.n.visible) {
                         tanFrame.visible = true;
                         arrows.n.visible = true;
@@ -556,13 +556,13 @@
     };
 
     const shiftUp = (e) => {
-        if (e.key === 'Shift') {
-            window.removeEventListener('mousemove', onMouseMove);
+        if (e.key === "Shift") {
+            window.removeEventListener("mousemove", onMouseMove);
         }
     };
 
-    window.addEventListener('keydown', shiftDown, false);
-    window.addEventListener('keyup', shiftUp, false);
+    window.addEventListener("keydown", shiftDown, false);
+    window.addEventListener("keyup", shiftUp, false);
 </script>
 
 <div class="boxItem" class:selected on:click on:keydown>
@@ -572,7 +572,7 @@
     </div>
     <div {hidden}>
         <div class="threedemos-container container">
-            {#each ['x', 'y', 'z'] as name}
+            {#each ["x", "y", "z"] as name}
                 <span class="box-1"><M size="sm">{name}(u,v) =</M></span>
                 <InputChecker
                     value={params[name]}
@@ -593,10 +593,10 @@
                     const val = e.target.value;
                     if (chickenParms(params.x, params)) {
                         params.a = val;
-                        e.target.classList.remove('is-invalid');
+                        e.target.classList.remove("is-invalid");
                         // updateSurface();
                     } else {
-                        e.target.classList.add('is-invalid');
+                        e.target.classList.add("is-invalid");
                     }
                 }}
             />
@@ -609,10 +609,10 @@
                     const val = e.target.value;
                     if (chickenParms(params.x, params)) {
                         params.b = val;
-                        e.target.classList.remove('is-invalid');
+                        e.target.classList.remove("is-invalid");
                         // updateSurface();
                     } else {
-                        e.target.classList.add('is-invalid');
+                        e.target.classList.add("is-invalid");
                     }
                 }}
             />
@@ -624,10 +624,10 @@
                     const val = e.target.value;
                     if (chickenParms(params.x, params)) {
                         params.c = val;
-                        e.target.classList.remove('is-invalid');
+                        e.target.classList.remove("is-invalid");
                         // updateSurface();
                     } else {
-                        e.target.classList.add('is-invalid');
+                        e.target.classList.add("is-invalid");
                     }
                 }}
             />
@@ -639,10 +639,10 @@
                     const val = e.target.value;
                     if (chickenParms(params.x, params)) {
                         params.d = val;
-                        e.target.classList.remove('is-invalid');
+                        e.target.classList.remove("is-invalid");
                         // updateSurface();
                     } else {
-                        e.target.classList.add('is-invalid');
+                        e.target.classList.add("is-invalid");
                     }
                 }}
             />

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -610,15 +610,15 @@
         // tangents
         if (tanFrame.visible) {
             console.log(point);
-            const u = point.uv.u;
-            const v = point.uv.v;
+            const u = point.uv.x;
+            const v = point.uv.y;
             const [U, V] = abcd(u, v);
 
             xyz(U, V, vec, t);
 
             point.position.copy(vec);
 
-            tangentVectors();
+            tangentVectors({ uv: point.uv });
         }
     };
 
@@ -746,7 +746,7 @@
 
     // Construct tangent vectors at a point u,v (both 0 to 1)
     const tangentVectors = function ({ uv, eps = 1e-4, plane = true } = {}) {
-        const { a, b, c, d } = params;
+        const { a, b, c, d, t0, t1 } = params;
         const A = math.parse(a).evaluate(),
             B = math.parse(b).evaluate();
         const [C, D] = math.parse([c, d]);
@@ -755,10 +755,16 @@
             U,
             (1 - uv.y) * C.evaluate({ u: U }) + uv.y * D.evaluate({ u: U }),
         ];
+
+        const T0 = t0 ? math.evaluate(t0) : 0;
+        const T1 = t1 ? math.evaluate(t1) : 1;
+
+        const t = T0 + tau * (T1 - T0);
+
         const { p, ru, rv, n } = rFrame({
             r: (u, v) => {
                 const out = new THREE.Vector3();
-                xyz(u, v, out);
+                xyz(u, v, out, t);
                 return out;
             },
             uv: uvs,
@@ -1037,7 +1043,7 @@
                 <!-- </div> -->
             {/if}
 
-            <span class="box-1"><M size="sm">u</M>-meshes</span>
+            <!-- <span class="box-1"><M size="sm">u</M>-meshes</span>
             <input
                 type="range"
                 bind:value={rNum}
@@ -1054,7 +1060,7 @@
                 max="20"
                 step="1"
                 class="box box-2"
-            />
+            /> -->
             <span class="box-1">Resolution</span>
             <input
                 type="range"

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -609,7 +609,6 @@
 
         // tangents
         if (tanFrame.visible) {
-            console.log(point);
             const u = point.uv.x;
             const v = point.uv.y;
             const [U, V] = abcd(u, v);
@@ -661,7 +660,7 @@
     onMount(() => {
         params.t0 = params.t0 || '0';
         params.t1 = params.t1 || '1';
-        updateSurface();
+        // updateSurface();
         if (animation) dispatch('animate');
     });
     // afterUpdate(() => {
@@ -1029,7 +1028,19 @@
                     }}
                     class="box box-2"
                 />
-
+                <span class="box-1" style="text-align: center;">
+                    Tangents&nbsp;
+                    <label class="switch box box-3">
+                        <input
+                            type="checkbox"
+                            name="tangentsToggle"
+                            id="tangentsToggle"
+                            bind:checked={tanFrame.visible}
+                            on:change={render}
+                        />
+                        <span class="slider round" />
+                    </label>
+                </span>
                 <PlayButtons
                     bind:animation
                     on:animate
@@ -1146,6 +1157,7 @@
 
     .colorbar-container {
         grid-column: 1 / -1;
-        height: 30px;
+        height: 2.5rem;
+        margin-bottom: 5px;
     }
 </style>

--- a/media/src/settings/ColorBar.svelte
+++ b/media/src/settings/ColorBar.svelte
@@ -1,0 +1,63 @@
+<script>
+    import { onMount } from "svelte";
+    import { blueUpRedDown } from "../utils";
+
+    export let vMin = 0;
+    export let vMax = 1;
+
+    let container;
+    let canvas;
+    let labels;
+
+    let vRange;
+
+    onMount(() => {
+        canvas.width = container.clientWidth / 2;
+        canvas.height = container.clientHeight;
+
+        const context = canvas.getContext("2d");
+
+        // add linear gradient
+        const grd = context.createLinearGradient(0, canvas.height, 0, 0);
+
+        vRange = vMax - vMin;
+        for (let x = 0; x <= 1; x += 0.125) {
+            const hexString = blueUpRedDown(x * 2 - 1).getHexString();
+            grd.addColorStop(x, "#" + hexString);
+        }
+        context.fillStyle = grd;
+        context.fillRect(0, 0, canvas.width, canvas.height);
+    });
+</script>
+
+<div class="container colorbar" bind:this={container}>
+    <canvas id="colorbar" bind:this={canvas} />
+    <div class="colorBarTextContainer" bind:this={labels}>
+        {#each [0, 1, 2, 3, 4, 5, 6, 7, 8] as x}
+            <div class="colorBarText" style={`${12.5 * x}%`}>
+                {(Math.round((vMin + x * vRange) * 100) / 100).toString()}
+            </div>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .colorbar {
+        height: 60%;
+        width: 50px;
+        position: absolute;
+        right: 20px;
+        top: 20%;
+        z-index: 50;
+        display: block;
+    }
+
+    canvas {
+        height: 100%;
+    }
+
+    .colorBarText {
+        left: 0px;
+        vertical-align: text-top;
+    }
+</style>

--- a/media/src/settings/ColorBar.svelte
+++ b/media/src/settings/ColorBar.svelte
@@ -1,6 +1,6 @@
 <script>
-    import { onMount } from "svelte";
-    import { blueUpRedDown } from "../utils";
+    import { onMount } from 'svelte';
+    import { blueUpRedDown } from '../utils';
 
     export let vMin = 0;
     export let vMax = 1;
@@ -9,21 +9,20 @@
     let canvas;
     let labels;
 
-    let vRange;
+    $: vRange = vMax - vMin;
 
     onMount(() => {
-        canvas.width = container.clientWidth / 2;
-        canvas.height = container.clientHeight;
+        canvas.width = container.clientWidth;
+        canvas.height = container.clientHeight / 2;
 
-        const context = canvas.getContext("2d");
+        const context = canvas.getContext('2d');
 
         // add linear gradient
-        const grd = context.createLinearGradient(0, canvas.height, 0, 0);
+        const grd = context.createLinearGradient(0, 0, canvas.width, 0);
 
-        vRange = vMax - vMin;
         for (let x = 0; x <= 1; x += 0.125) {
             const hexString = blueUpRedDown(x * 2 - 1).getHexString();
-            grd.addColorStop(x, "#" + hexString);
+            grd.addColorStop(x, '#' + hexString);
         }
         context.fillStyle = grd;
         context.fillRect(0, 0, canvas.width, canvas.height);
@@ -33,31 +32,32 @@
 <div class="container colorbar" bind:this={container}>
     <canvas id="colorbar" bind:this={canvas} />
     <div class="colorBarTextContainer" bind:this={labels}>
-        {#each [0, 1, 2, 3, 4, 5, 6, 7, 8] as x}
-            <div class="colorBarText" style={`${12.5 * x}%`}>
-                {(Math.round((vMin + x * vRange) * 100) / 100).toString()}
-            </div>
+        {#each [0, 1, 2, 3, 4] as x}
+            <span class="colorBarText" style="left: {(100 * x) / 4}%">
+                {(Math.round((vMin + (x / 4) * vRange) * 100) / 100).toString()}
+            </span>
         {/each}
     </div>
 </div>
 
 <style>
     .colorbar {
-        height: 60%;
-        width: 50px;
-        position: absolute;
-        right: 20px;
-        top: 20%;
+        height: 50%;
+        width: 90%;
         z-index: 50;
-        display: block;
     }
 
     canvas {
-        height: 100%;
+        width: 100%;
+    }
+
+    .colorBarTextContainer {
+        display: flex;
+        justify-content: space-between;
     }
 
     .colorBarText {
-        left: 0px;
-        vertical-align: text-top;
+        top: 1px;
+        font-family: monospace;
     }
 </style>

--- a/objectExamples/parsurfExample.json
+++ b/objectExamples/parsurfExample.json
@@ -1,6 +1,6 @@
 [
     {
-        "kind": "parsurf",
+        "kind": "surface",
         "params": {
             "a": "0",
             "b": "2*pi",

--- a/objectExamples/variousExample.json
+++ b/objectExamples/variousExample.json
@@ -48,7 +48,7 @@
         }
     },
     {
-        "kind": "parsurf",
+        "kind": "surface",
         "params": {
             "a": "0",
             "b": "2*pi",


### PR DESCRIPTION
Bunch of updates for `ParSurf`:
  - rename component to `Surface` to align with others being plain words
  - **new** add dynamic response to $t$-dependence
  - **new** add colorization based on "density" scalar function. 
Try this query string: 
```
?currentChapter=Intro&flipInfo=true&shadeUp=true&obj0_kind=surface&obj0_color=%23680076&obj0_params_a=0&obj0_params_b=3+%2F+2*pi&obj0_params_c=pi&obj0_params_d=5*pi+%2F+2&obj0_params_x=cos%28u+%2B+t%29*%281+%2B+%281+%2B+sin%282t%29+%2F+2%29*sin%28v%29%2F3%29&obj0_params_y=sin%28u+%2B+t%29*%281+%2B+%281+%2B+sin%282t%29+%2F+2%29*sin%28v%29%2F3%29&obj0_params_z=-%281+%2B+sin%282t%29+%2F+2%29*cos%28v%29%2F3&obj0_params_f=x+%2F+10&obj0_params_t0=0&obj0_params_t1=2+pi
```

To jazz it up, select "Density" and enter a fun function like "sin(3*x)". Animate away.

Miscellaneous:
  - `.editorconfig` was overriding my single quotes pref. Fixed.
 
Further consideration:
  - `densityFunc` is purely intra-component at the moment. Should be an optional `param` probably, but I need to make sure it doesn't trigger too many updates. 
  - Considering making a density-like object that can be applied to other objects like the impending `Solid.svelte`
  - Need to fix the garish colors. Should let users select one of the [matplotlib colormaps](https://matplotlib.org/stable/tutorials/colors/colormaps.html) perhaps. First scan didn't find a nice js implementation.
