### PR TITLE
Fix bug where first "Make room" creates room as student

### DIFF
--- a/mathplayground/main/views.py
+++ b/mathplayground/main/views.py
@@ -7,6 +7,10 @@ from mathplayground.rooms.scene import make_room
 
 @require_http_methods(['GET', 'POST'])
 def index(request):
+    # Make sure the user's session is created.
+    if not request.session.session_key:
+        request.session.create()
+
     if request.method == 'POST':
         data = request.POST
         room_id = make_room(


### PR DESCRIPTION
This is a quick fix to fix the bug that can be reproduced with these steps:
1. open 3demos in private tab
2. click Session -> Make Room

User will be Student rather than Host.

Django doesn't create the user's session by default. We created this explicitly in the room view, but not the index view, causing this bug.

There may be a nicer fix to enable this globally, but for now this works.