### PR TITLE
Only create session when necessary

### DIFF
--- a/mathplayground/main/views.py
+++ b/mathplayground/main/views.py
@@ -7,11 +7,11 @@ from mathplayground.rooms.scene import make_room
 
 @require_http_methods(['GET', 'POST'])
 def index(request):
-    # Make sure the user's session is created.
-    if not request.session.session_key:
-        request.session.create()
-
     if request.method == 'POST':
+        # Make sure the user's session is created.
+        if not request.session.session_key:
+            request.session.create()
+
         data = request.POST
         room_id = make_room(
             data.get('objects'),


### PR DESCRIPTION
Minor adjustment for my fix for session creation: we currently only use the session when the user wants to make a room. So, only create one on the form POST.

This way, the fix is still in place, but session stuff won't be touched at all if the user isn't touching the session functionality.