### PR TITLE
Bootstrap form input adjustments: use smaller inputs everywhere

### DIFF
--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -445,7 +445,7 @@
 
             <ObjectParamInput
                 type="number"
-                className="form-control box"
+                className="form-control form-control-sm box"
                 initialValue={params.a}
                 onChange={(newVal) => {
                     params.a = newVal;
@@ -454,7 +454,7 @@
             <span class="box box-3"><M size="sm">\leq x \leq</M></span>
             <ObjectParamInput
                 type="number"
-                className="form-control box"
+                className="form-control form-control-sm box"
                 initialValue={params.b}
                 onChange={(newVal) => {
                     params.b = newVal;
@@ -463,7 +463,7 @@
 
             <ObjectParamInput
                 type="number"
-                className="form-control box"
+                className="form-control form-control-sm box"
                 initialValue={params.c}
                 onChange={(newVal) => {
                     params.c = newVal;
@@ -472,7 +472,7 @@
             <span class="box box-3"><M size="sm">\leq y \leq</M></span>
             <ObjectParamInput
                 type="number"
-                className="form-control box"
+                className="form-control form-control-sm box"
                 initialValue={params.d}
                 onChange={(newVal) => {
                     params.d = newVal;
@@ -481,7 +481,7 @@
 
             <ObjectParamInput
                 type="number"
-                className="form-control box"
+                className="form-control form-control-sm box"
                 initialValue={params.e}
                 onChange={(newVal) => {
                     params.e = newVal;
@@ -490,7 +490,7 @@
             <span class="box box-3"><M size="sm">\leq z \leq</M></span>
             <ObjectParamInput
                 type="number"
-                className="form-control box"
+                className="form-control form-control-sm box"
                 initialValue={params.f}
                 onChange={(newVal) => {
                     params.f = newVal;

--- a/media/src/polls/Poll.svelte
+++ b/media/src/polls/Poll.svelte
@@ -68,7 +68,7 @@
                     <input type="number" step="0.01"
                            style="width: 100px;"
                            name="poll_response"
-                           class="form-control mb-2" />
+                           class="form-control form-control-sm mb-2" />
                 {/if}
 
                 {#if currentPoll.choices}

--- a/media/src/polls/PollForm.svelte
+++ b/media/src/polls/PollForm.svelte
@@ -48,7 +48,7 @@ Poll Form
     {/if}
 
     <textarea
-        class="form-control"
+        class="form-control form-control-sm"
         name="poll"
         rows="8">{stringifyPoll(poll)}</textarea>
 

--- a/media/src/session/Session.svelte
+++ b/media/src/session/Session.svelte
@@ -39,7 +39,7 @@
     <form on:submit|preventDefault={() => onJoinRoom(joinRoomId)}
         class="mt-2 row row-cols-lg-auto align-items-center">
         <div class="col-12">
-            <input type="text" class="form-control" id="joinRoomId"
+            <input type="text" class="form-control form-control-sm" id="joinRoomId"
                    placeholder="Room ID"
                    bind:value={joinRoomId} />
         </div>


### PR DESCRIPTION
Unify the form-control inputs: not all of them were using `form-control-sm`.