### PR TITLE
Make vMin/vMax universal

### DIFF
--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -8,7 +8,7 @@
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
     import PlayButtons from '../form-components/PlayButtons.svelte';
-    import { tickTock } from '../stores';
+    import { tickTock, vMax, vMin } from '../stores';
 
     const config = {};
     const math = create(all, config);
@@ -60,8 +60,6 @@
     let densityString = '1';
     let compiledDensity;
     let densityFunc;
-    let vMin = -1;
-    let vMax = 1;
     // export let myId;
 
     const colorMaterial = new THREE.MeshPhongMaterial({
@@ -162,20 +160,22 @@
     // });
 
     const colorMeBadd = (mesh, f) => {
-        [vMax, vMin] = vMaxMin(mesh, f);
-        if (vMax == vMin) {
-            if (vMax == 0) {
-                vMax = 1;
-                vMin = -1;
+        const [vMaxLocal, vMinLocal] = vMaxMin(mesh, f);
+        $vMin = Math.min($vMin, vMinLocal);
+        $vMax = Math.max($vMax, vMaxLocal);
+        if ($vMax == $vMin) {
+            if ($vMax == 0) {
+                $vMax = 1;
+                $vMin = -1;
             } else {
-                vMax = (4 / 3) * Math.abs(vMax);
-                vMin = (-4 / 3) * Math.abs(vMin);
+                $vMax = (4 / 3) * Math.abs($vMax);
+                $vMin = (-4 / 3) * Math.abs($vMin);
             }
         }
 
         colorBufferVertices(mesh, (x, y, z) => {
             const value = f(x, y, z);
-            return blueUpRedDown((2 * (value - vMin)) / (vMax - vMin) - 1);
+            return blueUpRedDown((2 * (value - $vMin)) / ($vMax - $vMin) - 1);
         });
     };
 
@@ -916,9 +916,7 @@
 </script>
 
 <div class="boxItem" class:selected on:click on:keydown>
-    <ObjHeader bind:hidden bind:onClose {color}>
-        Parametric surface
-    </ObjHeader>
+    <ObjHeader bind:hidden bind:onClose {color}>Parametric surface</ObjHeader>
     <div {hidden}>
         <div class="threedemos-container container">
             {#each ['x', 'y', 'z'] as name}
@@ -1126,7 +1124,7 @@
                     }}
                 />
                 <div class="box colorbar-container">
-                    <ColorBar {vMin} {vMax} />
+                    <ColorBar vMin={$vMin} vMax={$vMax} />
                 </div>
             {:else}
                 <span class="box box-2">

--- a/media/src/settings/Settings.svelte
+++ b/media/src/settings/Settings.svelte
@@ -4,6 +4,7 @@
     import { TextGeometry } from 'three/examples/jsm/geometries/TextGeometry.js';
     import { drawAxes, drawGrid, labelAxes, freeChildren } from '../utils';
     import { makeObject } from '../sceneUtils';
+    import { vMin, vMax } from '../stores';
     import WindowHeader from './WindowHeader.svelte';
 
     const dispatch = createEventDispatcher();
@@ -145,11 +146,14 @@
     class="settings-box"
     class:grid={showSettings}
     hidden={!showSettings}
-    id="settings-box">
-
-    <WindowHeader title="Settings" onClick={() => {
-        showSettings = false;
-    }} />
+    id="settings-box"
+>
+    <WindowHeader
+        title="Settings"
+        onClick={() => {
+            showSettings = false;
+        }}
+    />
 
     <div class="row justify-content-between">
         <div class="col-12">
@@ -197,17 +201,39 @@
             />
         </label>
     </div>
+    <div class="row justify-content-between">
+        <label
+            >vMin
+            <input type="number" bind:value={$vMin} />
+        </label>
+        <label
+            >vMax
+            <input type="number" bind:value={$vMax} />
+        </label>
+        <button
+            class="button settings-button"
+            aria-label="Reset the vmin/vmax for coloring."
+            on:click={() => {
+                $vMin = -1;
+                $vMax = 1;
+                render();
+            }}>Reset</button
+        >
+    </div>
 </div>
 
 <div
     class="settings-box"
     class:grid={showUpload}
     hidden={!showUpload}
-    id="upload-box">
-
-    <WindowHeader title="Upload Scene" onClick={() => {
-        showUpload = false;
-    }} />
+    id="upload-box"
+>
+    <WindowHeader
+        title="Upload Scene"
+        onClick={() => {
+            showUpload = false;
+        }}
+    />
 
     <form>
         <label for="sceneUpload">Upload a scene</label>
@@ -267,9 +293,9 @@
 </button>
 
 {#if roomId}
-<a href="/" class="button" title="Exit room">
-    <i class="fa fa-sign-out-alt" />
-</a>
+    <a href="/" class="button" title="Exit room">
+        <i class="fa fa-sign-out-alt" />
+    </a>
 {/if}
 
 <style>
@@ -281,7 +307,9 @@
         padding: 0.25rem 0.5rem;
         width: 3rem;
     }
-
+    .settings-button {
+        color: white;
+    }
     .settings-box {
         position: relative;
         color: white;

--- a/media/src/stores.js
+++ b/media/src/stores.js
@@ -2,3 +2,5 @@ import { writable } from 'svelte/store';
 
 // Make a store for "universal coordinated time"
 export const tickTock = writable(0.);
+export const vMin = writable(-1.);
+export const vMax = writable(1.);


### PR DESCRIPTION
Make vmin/vmax consistent across objects. 

Basically just expands the range to encompass all objects using the density function. Reset button in Settings reverts to (-1, 1) but can be instantly overwritten if larger values present. Not sure if this is optimal for user. 

TODO:
  - Style/bootstrapify elements in the Settings box. (Make reset an icon, maybe?)
