### PR TITLE
cleanup: Remove unused panel flexbox styles

### DIFF
--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -268,12 +268,12 @@
     $: minWidth = showPanel ? 300 : 0;
 </script>
 
-<div class="demos-panel d-flex flex-column"
+<div class="demos-panel"
      style:transition={panelTransition}
      style:transition-property={panelTransitionProperty}
      style:width={panelWidth + 'px'}
      style:min-width={minWidth + 'px'}>
-<div id="panelAccordion" class="accordion flex-fill">
+<div id="panelAccordion" class="accordion">
     <h1 class="flex-grow-1 px-2">
         <a href="/" title="Home">3Demos (βeta)</a>
     </h1>


### PR DESCRIPTION
This doesn't make any real functional changes that I'm aware of. I just noticed these styles aren't necessary, so I'm removing them in the interest of simplifying things as we work to address #486 and possibly the pinned accordion item headers functionality that's been mentioned before as well.

https://getbootstrap.com/docs/5.3/utilities/flex/