### PR TITLE
Restore visibility to backMesh

### DIFF
--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -289,7 +289,7 @@
         color: 0xff3232,
         shininess: 80,
         side: THREE.BackSide,
-        vertexColors: true,
+        vertexColors: false,
         transparent: true,
         opacity: 0.7,
     });
@@ -379,7 +379,7 @@
         tanFrame.visible = false;
         tangentVectors({ uv: new THREE.Vector2(0, 0) });
 
-        console.log('hello', geometry.attributes, meshGeometry.attributes);
+        // console.log('hello', geometry.attributes, meshGeometry.attributes);
         render();
     };
 
@@ -1009,7 +1009,7 @@
                     />
                 {/each}
 
-                <span class="box-1 ">
+                <span class="box-1">
                     <span class="t-box">t = {texString1}</span>
                 </span>
                 <input


### PR DESCRIPTION
Bug fix. 
`backMesh` wasn't visible when `chooseDensity` is false. 