### PR TITLE
Fix input display for numeric poll type

### DIFF
--- a/media/src/polls/Poll.svelte
+++ b/media/src/polls/Poll.svelte
@@ -81,7 +81,7 @@
                     {currentPoll.prompt}
                 </div>
 
-                {#if currentPoll.type === 0}
+                {#if currentPoll.type === 'numeric'}
                     <input type="number" step="0.01"
                            style="width: 100px;"
                            name="poll_response"


### PR DESCRIPTION
We're using a string as the poll type instead of a number.