### PR TITLE
Use triple-equals for comparison

### DIFF
--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -128,7 +128,7 @@
     });
     // Keep updated
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             curveMaterial.opacity = 1.0;
         } else {
             curveMaterial.opacity = 0.1;

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -80,7 +80,7 @@
     let interpretColor;
     // Keep color fresh
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             fieldMaterial.opacity = 1.0;
         } else {
             fieldMaterial.opacity = 0.3;

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -560,7 +560,7 @@
 
     // Keep color fresh
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             plusMaterial.opacity = 0.7;
             minusMaterial.opacity = 0.7;
         } else {

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -72,7 +72,7 @@
 
     // $: col = new THREE.Color(color);
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             plusMaterial.opacity = 0.7;
             minusMaterial.opacity = 0.7;
         } else {

--- a/media/src/objects/Point.svelte
+++ b/media/src/objects/Point.svelte
@@ -102,7 +102,7 @@
 
     // recolor on demand
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             pointMaterial.opacity = 1.0;
         } else {
             pointMaterial.opacity = 0.3;

--- a/media/src/objects/Solid.svelte
+++ b/media/src/objects/Solid.svelte
@@ -171,7 +171,7 @@
     });
 
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             material.opacity = 1.0;
             colorMaterial.opacity = 1.0;
         } else {

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -306,7 +306,7 @@
 
     // Keep color fresh
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             plusMaterial.opacity = 0.7;
             minusMaterial.opacity = 0.7;
         } else {

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -161,7 +161,7 @@
 
     // recolor on demand
     $: {
-        if (selectedObject == null || selected) {
+        if (selectedObject === null || selected) {
             arrowMaterial.opacity = 1.0;
         } else {
             arrowMaterial.opacity = 0.3;


### PR DESCRIPTION
Strict equality is easier to reason about and in practice, I haven't found a use for loose equality. I suppose it's worth refreshing my memory on, though:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness