### PR TITLE
Make panel `fit-content`able

### DIFF
--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -97,147 +97,115 @@
         return tripleToHex(cm);
     };
 
-    const onClickPoint = function () {
-        objects = [
-            ...objects,
-            {
-                uuid: crypto.randomUUID(),
-                kind: 'point',
-                params: {
-                    a: `${Math.random()}`.slice(0, 5),
-                    b: `${Math.random()}`.slice(0, 5),
-                    c: `${Math.random()}`.slice(0, 5),
-                    t0: '0',
-                    t1: '1',
-                },
-                color: nextColorUp(),
-            },
-        ];
+    /**
+     * This is a object of functions, keyed on the 3demos object kind, which return a (randomized) default
+     * for each object kind.
+     */
+    const defaultParams = {
+        point: () => ({
+            a: `${Math.random()}`.slice(0, 5),
+            b: `${Math.random()}`.slice(0, 5),
+            c: `${Math.random()}`.slice(0, 5),
+            t0: '0',
+            t1: '1',
+        }),
+        vector: () => ({
+            a: `${2 * Math.random() - 1}`.slice(0, 5),
+            b: `${2 * Math.random() - 1}`.slice(0, 5),
+            c: `${2 * Math.random() - 1}`.slice(0, 5),
+            x: '0',
+            y: '0',
+            z: '0',
+            t0: '0',
+            t1: '1',
+        }),
+        curve: () => ({
+            a: '0',
+            b: '2*pi',
+            x: 'cos(t)',
+            y: 'sin(t)',
+            z: `${
+                1 / 4 + Math.round(100 * Math.random()) / 100
+            } * cos(${Math.ceil(10 * Math.random()).toString()}*t)`,
+        }),
+        graph: () => ({
+            a: '-2',
+            b: '2',
+            c: '-2',
+            d: '2',
+            z: `${Math.ceil(
+                4 * Math.random()
+            ).toString()} / 4 * cos(${Math.ceil(
+                3 * Math.random()
+            ).toString()}*x + ${Math.ceil(
+                2 * Math.random()
+            ).toString()}*y)/(1 + x^2 + y^2)`,
+            t0: '0',
+            t1: '1',
+        }),
+        level: () => ({
+            g: (Math.random() > 0.5 ? '-' : '') + 'x^2 + 2 y^2 - z^2',
+            k: (Math.ceil(16 * Math.random()) / 2 - 4).toString(),
+            a: '-2',
+            b: '2',
+            c: '-2',
+            d: '2',
+            e: '-2',
+            f: '2',
+        }),
+        surface: () => {
+            const k = Math.ceil(10 * Math.random());
+            const l = Math.ceil(10 * Math.random());
+            const R = (k / 20).toString();
+            return {
+                a: '0',
+                b: `${(2.1 - k / 10).toString()} * pi`,
+                c: `${(l / 10).toString()} * pi`,
+                d: `${(l / 10 + 1).toString()} * pi`,
+                x: `cos(u)*(1 + ${R}*sin(v))`,
+                y: `sin(u)*(1 + ${R}*sin(v))`,
+                z: `-${R}*cos(v)`,
+            };
+        },
+        solid: () => {
+            const k = Math.ceil(10 * Math.random());
+            const l = Math.ceil(10 * Math.random());
+            const m = Math.ceil(10 * Math.random());
+            const n = Math.ceil(10 * Math.random());
+            return {
+                coords: 'rect',
+                a: `-${k / 5}`,
+                b: `${l / 5}`,
+                c: `-${m / 5}`,
+                d: `${n / 5}`,
+                e: '0',
+                f: `1 - ((x - ${m / 10})^2 + (y + ${k / 10})^2) / 8`,
+            };
+        },
+        field: () => {
+            const comps = ['1', '-1', 'x', 'y', 'z', '-x', '-y', '-z'];
+            const p = comps[Math.ceil(comps.length * Math.random())];
+            const q = comps[Math.ceil(comps.length * Math.random())];
+            const r = comps[Math.ceil(comps.length * Math.random())];
+            return { p, q, r, nVec: 6 };
+        },
     };
 
-    const onClickVector = function () {
-        objects = [
-            ...objects,
-            {
-                uuid: crypto.randomUUID(),
-                kind: 'vector',
-                params: {
-                    a: `${2 * Math.random() - 1}`.slice(0, 5),
-                    b: `${2 * Math.random() - 1}`.slice(0, 5),
-                    c: `${2 * Math.random() - 1}`.slice(0, 5),
-                    x: '0',
-                    y: '0',
-                    z: '0',
-                    t0: '0',
-                    t1: '1',
-                },
-                // color: `#${makeHSLColor(Math.random()).getHexString()}`,
-                color: nextColorUp(),
-            },
-        ];
-    };
+    let kindToAdd = null;
 
-    const onClickSpaceCurve = function () {
+    $: if (kindToAdd) {
         objects = [
             ...objects,
             {
                 uuid: crypto.randomUUID(),
-                kind: 'curve',
-                params: {
-                    a: '0',
-                    b: '2*pi',
-                    x: 'cos(t)',
-                    y: 'sin(t)',
-                    z: `${
-                        1 / 4 + Math.round(100 * Math.random()) / 100
-                    } * cos(${Math.ceil(10 * Math.random()).toString()}*t)`,
-                },
+                kind: kindToAdd,
+                params: defaultParams[kindToAdd](),
                 color: nextColorUp(),
             },
         ];
-    };
 
-    const onClickGraph = function () {
-        objects = [
-            ...objects,
-            {
-                uuid: crypto.randomUUID(),
-                kind: 'graph',
-                params: {
-                    a: '-2',
-                    b: '2',
-                    c: '-2',
-                    d: '2',
-                    z: `cos(${Math.ceil(
-                        3 * Math.random()
-                    ).toString()}*x + ${Math.ceil(
-                        2 * Math.random()
-                    ).toString()}*y)/(1 + x^2 + y^2)`,
-                    t0: '0',
-                    t1: '1',
-                },
-                color: nextColorUp(),
-            },
-        ];
-    };
-
-    const onClickLevelSurface = function () {
-        objects = [
-            ...objects,
-            {
-                uuid: crypto.randomUUID(),
-                kind: 'level',
-                params: {
-                    g: 'x^2 + 2 y^2 - z^2',
-                    k: '1',
-                    a: '-2',
-                    b: '2',
-                    c: '-2',
-                    d: '2',
-                    e: '-2',
-                    f: '2',
-                },
-                color: nextColorUp(),
-            },
-        ];
-    };
-
-    const onClickParSurf = function () {
-        objects = [
-            ...objects,
-            {
-                uuid: crypto.randomUUID(),
-                kind: 'surface',
-                params: {
-                    a: '0',
-                    b: '2*pi',
-                    c: '0',
-                    d: '2*pi',
-                    x: 'cos(u)*(1 + sin(v)/3)',
-                    y: 'sin(u)*(1 + sin(v)/3)',
-                    z: '-cos(v)/3',
-                },
-                color: nextColorUp(),
-            },
-        ];
-    };
-
-    const onClickVectorField = function () {
-        objects = [
-            ...objects,
-            {
-                uuid: crypto.randomUUID(),
-                kind: 'field',
-                params: {
-                    p: 'y',
-                    q: 'z',
-                    r: 'x',
-                    nVec: 6,
-                },
-                color: nextColorUp(),
-            },
-        ];
-    };
+        kindToAdd = null;
+    }
 
     const onTogglePanel = function () {
         panelTransition = `all ${PANEL_DELAY}ms ease`;
@@ -376,7 +344,7 @@
                         <TabContent on:tab={(e) => (currentMode = e.detail)}>
                             <TabPane
                                 tabId="how-to"
-                                tab="How To"
+                                tab="Creation"
                                 active={currentMode === 'how-to'}
                             >
                                 <HowTo />
@@ -481,79 +449,26 @@
                             role="toolbar"
                         >
                             <div class="btn-group mb-2">
-                                <ButtonDropdown>
-                                    <DropdownToggle size="sm" color="primary">
-                                        Add Object
-                                        <i class="fa fa-plus" />
-                                    </DropdownToggle>
-                                    <DropdownMenu>
-                                        <DropdownItem on:click={onClickPoint}>
-                                            Point <M size="sm"
-                                                >P = ( a, b, c )</M
-                                            >
-                                        </DropdownItem>
-                                        <DropdownItem on:click={onClickVector}>
-                                            Vector <M size="sm"
-                                                >\mathbf v = \langle a, b, c
-                                                \rangle</M
-                                            >
-                                        </DropdownItem>
-                                        <DropdownItem
-                                            on:click={onClickSpaceCurve}
-                                        >
-                                            Space Curve <M size="sm"
-                                                >\mathbf r(t)</M
-                                            >
-                                        </DropdownItem>
-                                        <DropdownItem on:click={onClickGraph}>
-                                            Graph <M size="sm">z = f(x,y)</M>
-                                        </DropdownItem>
-                                        <DropdownItem
-                                            on:click={onClickLevelSurface}
-                                        >
-                                            Level Surface <M size="sm"
-                                                >g(x,y,z) = k</M
-                                            >
-                                        </DropdownItem>
-                                        <DropdownItem on:click={onClickParSurf}>
-                                            Parametric Surface <M size="sm"
-                                                >\mathbf r(u,v)</M
-                                            >
-                                        </DropdownItem>
-                                        <DropdownItem
-                                            on:click={() => {
-                                                objects = [
-                                                    ...objects,
-                                                    {
-                                                        uuid: crypto.randomUUID(),
-                                                        kind: 'solid',
-                                                        params: {
-                                                            coords: 'rect',
-                                                            a: '-1',
-                                                            b: '1',
-                                                            c: '-1',
-                                                            d: 'x',
-                                                            e: '0',
-                                                            f: '1 - (x^2 + y^2) / 2',
-                                                        },
-                                                        color: nextColorUp(),
-                                                    },
-                                                ];
-                                            }}
-                                        >
-                                            Solid Region <M size="sm"
-                                                >{'E \\subset \\mathbb{R}^3'}</M
-                                            >
-                                        </DropdownItem>
-                                        <DropdownItem
-                                            on:click={onClickVectorField}
-                                        >
-                                            Vector Field<M size="sm"
-                                                >\mathbf F(x,y,z)</M
-                                            >
-                                        </DropdownItem>
-                                    </DropdownMenu>
-                                </ButtonDropdown>
+                                <select
+                                    bind:value={kindToAdd}
+                                    name="add-object-menu"
+                                    id="add-object-menu"
+                                >
+                                    <option value={null}
+                                        >Add Object &#xFF0B;</option
+                                    >
+                                    <option value="point">point</option>
+                                    <option value="vector">vector</option>
+                                    <option value="curve">curve</option>
+                                    <option value="graph">graph</option>
+                                    <option value="level">level surface</option>
+                                    <option value="surface"
+                                        >parametric surface</option
+                                    >
+                                    <option value="solid">solid region</option>
+                                    <option value="field">vector field</option>
+                                </select>
+
                                 <button
                                     class="btn btn-sm btn-danger"
                                     on:click={blowUpObjects}
@@ -853,6 +768,9 @@
         min-width: 300px;
         max-width: 60%;
 
+        height: fit-content;
+        max-height: 100%;
+
         background-color: transparent;
 
         overflow-y: auto;
@@ -916,5 +834,12 @@
         display: flex;
         font-size: 1.5em;
         justify-content: space-between;
+    }
+
+    select {
+        background-color: blue;
+        color: white;
+        /* font-size: 1.25em; */
+        padding: 5px;
     }
 </style>

--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -6,14 +6,7 @@
     import { slide } from 'svelte/transition';
     import { quintOut } from 'svelte/easing';
 
-    import {
-        ButtonDropdown,
-        DropdownItem,
-        DropdownMenu,
-        DropdownToggle,
-        TabContent,
-        TabPane,
-    } from 'sveltestrap';
+    import { TabContent, TabPane } from 'sveltestrap';
 
     import HowTo from './docs/HowTo.svelte';
     import About from './docs/About.svelte';
@@ -37,7 +30,6 @@
     import Point from './objects/Point.svelte';
     import Solid from './objects/Solid.svelte';
 
-    import M from './M.svelte';
     import { evaluate_cmap } from './js-colormaps';
     import { colorMap } from './stores';
 

--- a/media/src/docs/Badge.svelte
+++ b/media/src/docs/Badge.svelte
@@ -1,0 +1,7 @@
+<script>
+    export let type = 'secondary';
+</script>
+
+<strong class={`badge rounded-pill text-bg-${type}`}>
+    <slot><!-- optional fallback --></slot>
+</strong>

--- a/media/src/docs/DocKeyControls.svelte
+++ b/media/src/docs/DocKeyControls.svelte
@@ -1,20 +1,19 @@
 <script>
-    import M from "../M.svelte";
-    export let badge = function() {};
+    import M from '../M.svelte';
+    import Badge from './Badge.svelte';
 </script>
 
 <ul>
     <li>
-        {@html badge('Esc', 'secondary')}
+        <Badge>Esc</Badge>
         Hide/Show the MENU
     </li>
     <li>
-        {@html badge('Backspace', 'secondary')}
+        <Badge>Backspace</Badge>
         Hide/Show the selected object
     </li>
     <li>
-        {@html badge('p', 'secondary')}
-        Play/Pause animation for the selected object.
+        <Badge>p</Badge> Play/Pause animation for the selected object.
         <ul>
             <li>Requires <M size="sm">t</M> variable.</li>
             <li>Not available for <em>Solid Region</em> objects.</li>
@@ -24,37 +23,41 @@
 <strong><u>Tangent Controls - Space Curve</u></strong>
 <ul>
     <li>
-        {@html badge('t', 'secondary')}
+        <Badge>t</Badge>
         Hide/Show tangent elements.
     </li>
     <li>
-        {@html badge('o', 'secondary')}
-        Hide/Show oscillating circle. <em>Only works when the animation is playing.</em>
+        <Badge>o</Badge>
+        Hide/Show oscillating circle.
+        <em>Only works when the animation is playing.</em>
     </li>
 </ul>
 <div style="text-indent:-2rem; margin-left:2rem;">
-    <strong><u>Tangent Controls - Graph / Level Surface / Parametric Surface</u></strong>
+    <strong
+        ><u>Tangent Controls - Graph / Level Surface / Parametric Surface</u
+        ></strong
+    >
 </div>
 <ul>
     <li>
-        {@html badge('Hold Shift, Hover cursor over selected object', 'secondary')}
+        <Badge><kbd>Shift</kbd> + <em>hover</em></Badge>
         Moves the tangent point on the object.
     </li>
     <li>
-        {@html badge('c', 'secondary')}
+        <Badge>c</Badge>
         Sets the camera focus to the tangent point.
     </li>
     <li>
-        {@html badge('t', 'secondary')}
+        <Badge>t</Badge>
         Hide/Show tangent elements. Makes the tangent point visible.
     </li>
     <ul>
         <li>
-            {@html badge('y', 'secondary')}
+            <Badge>y</Badge>
             Hide/Show the tangent plane.
         </li>
         <li>
-            {@html badge('n', 'secondary')}
+            <Badge>n</Badge>
             Hide/Show the normal to the tangent plane.
         </li>
     </ul>
@@ -62,27 +65,24 @@
 <strong><u>Additional Level Surface Controls</u></strong>
 <ul>
     <li>
-        {@html badge('b', 'secondary')}
+        <Badge>b</Badge>
         Show integration boxes.
     </li>
     <ul>
         <li>
-            {@html badge('&lt;', 'secondary')}
-            Decrease the number of integral divisions.
-        </li>
-        <li>
-            {@html badge('&gt;', 'secondary')}
-            Increase the number of integral divisions.
+            <Badge>&lt; / &gt;</Badge>
+            Decrease/increase the number of integral divisions.
         </li>
     </ul>
     <li>
-        {@html badge('l', 'secondary')}
-        Turn on topography
+        <Badge>l</Badge>
+        Display/hide level curves.
     </li>
     <ul>
         <li>
-            {@html badge('0', 'secondary')}
-            Switch topographic representation between 2D and 3D.
+            <Badge>0</Badge>
+            Toggle level sets displayed on graph <M size="sm">z = f(x,y)</M> vs.
+            in plane <M size="sm">z = 0</M>.
         </li>
     </ul>
 </ul>

--- a/media/src/docs/DocObjWindow.svelte
+++ b/media/src/docs/DocObjWindow.svelte
@@ -1,38 +1,38 @@
 <script>
-    export let badge = function() {};
+    import Badge from './Badge.svelte';
 </script>
 
 <p>
-    The {@html badge('Objects', 'secondary')} window is used to create, modify, hide, and
-    destroy objects.
+    The <Badge>Objects</Badge> window is used to create, modify, hide, and destroy
+    objects.
 </p>
-New objects are created using {@html badge('Add Object', 'primary')}. Clicking on an
-object type will add a new instance of that object to the scene. A card will be visible in
-the {@html badge('Objects', 'secondary')} window. The header will contain a color swatch
-corresponding to the color of that object, the object type, and three buttons.
+New objects are created using <Badge type="primary">Add Object</Badge>. Clicking
+on an object type will add a new instance of that object to the scene. A card
+will be visible in the <Badge>Objects</Badge> window. The header will contain a color
+swatch corresponding to the color of that object, the object type, and three buttons.
 <ul>
     <li>
-        {@html badge('<i class="fa fa-eye"></i> / <i class="fa fa-eye-slash"></i>', 'secondary')}
+        <Badge><i class="fa fa-eye" /> / <i class="fa fa-eye-slash" /></Badge>
         hides/reveals the object.
     </li>
     <li>
-        {@html badge('<i class="fa fa-window-minimize"></i>', 'secondary')}
+        <Badge><i class="fa fa-window-minimize" /></Badge>
         collapses/expands the object card.
     </li>
     <li>
-        {@html badge('<i class="fa fa-window-close"></i>', 'secondary')}
+        <Badge><i class="fa fa-window-close" /></Badge>
         destroys the object.
     </li>
 </ul>
 <p>
-    {@html badge('Clear Objects', 'danger')} destroys all the objects in the scene.
+    <Badge type="danger">Clear Objects</Badge> destroys all the objects in the scene.
 </p>
-You can <em>SELECT</em> an object by
+You can<em>SELECT</em> an object by
 <ol>
     <li>Clicking on the object title in the card header.</li>
     <li>Double-clicking on the object in the scene.</li>
 </ol>
 <div class="p-2 border border-2 rounded-2">
-    Object selection is indicated by a white border around the selected object card and a
-    visual change to the object in the scene.
+    Object selection is indicated by a white border around the selected object
+    card and a visual change to the object in the scene.
 </div>

--- a/media/src/docs/DocPolling.svelte
+++ b/media/src/docs/DocPolling.svelte
@@ -1,28 +1,30 @@
 <script>
-    export let badge = function() {};
+    import Badge from './Badge.svelte';
 </script>
 
 <p>
-    Polling is only available in a <em>Session</em> and can only be initiated by the
-    <em>Host</em>. There are several default polls available which can be quickly modified using
-    the {@html badge('<i class="bi bi-pencil" /> Edit ', 'secondary')} found under the
+    Polling is only available in a <em>Session</em> and can only be initiated by
+    the
+    <em>Host</em>. There are several default polls available which can be
+    quickly modified using the <Badge><i class="bi bi-pencil" /> Edit</Badge> found
+    under the
     <em>Actions</em> column of the <em>Polls</em> table.
 </p>
 <p>
-    Keep in mind that {@html badge('Graph', 'secondary')},
-    {@html badge('Level Surface', 'secondary')}, and
-    {@html badge('Parametric Surface', 'secondary')} are the only objects that have selectable
-    points for the {@html badge('Select Point', 'secondary')} poll type.
+    Keep in mind that <Badge>Graph</Badge>,
+    <Badge>Level Surface</Badge>, and
+    <Badge>Parametric Surface</Badge> are the only objects that have selectable points
+    for the <Badge>Select Point</Badge> poll type.
 </p>
 <strong><u>Creating a new Poll</u></strong>
 <ul>
     <li>
-        In the bottom left of the {@html badge('Polls', 'secondary')} window is the
-        {@html badge('Make new poll', 'primary')} button.
+        In the bottom left of the <Badge>Polls</Badge> window is the
+        <Badge type="primary">Make New Polls</Badge> button.
     </li>
     <li>
-        New polls are already populated with defaults for a Multiple Choice Question, but
-        attributes can be changed to fit any question type.
+        New polls are already populated with defaults for a Multiple Choice
+        Question, but attributes can be changed to fit any question type.
     </li>
 </ul>
 <strong><u>Poll Attributes</u></strong>

--- a/media/src/docs/DocSession.svelte
+++ b/media/src/docs/DocSession.svelte
@@ -1,21 +1,24 @@
 <script>
-    export let badge = function() {};
+    import Badge from './Badge.svelte';
 </script>
+
 <p>
-    Sessions are used to present graphs and polls to an audience. Each session has a room with a
-    unique Room ID generated on creation. The creator of the room is the <em>Host</em> and is given
-    host features used to broadcast their object scene to the audience.
+    Sessions are used to present graphs and polls to an audience. Each session
+    has a room with a unique Room ID generated on creation. The creator of the
+    room is the <em>Host</em> and is given host features used to broadcast their
+    object scene to the audience.
 </p>
 <strong><u>Host Features</u></strong>
 <ul>
     <li>
-        {@html badge('Publish Scene', 'primary')}
-        Found in the {@html badge('Objects', 'secondary')} window. Used to send the current scene
+        <Badge type="primary">Publish Scene</Badge>
+        Found in the <Badge>Objects</Badge> window. Used to send the current scene
         to to the audience.
     </li>
     <li>
-        {@html badge('Polls', 'secondary')} window.
-        Displays the polls and poll responses.
+        <Badge>Polls</Badge> window. Displays the polls and poll responses.
     </li>
-    <li>A chat section will appear in the {@html badge('Info', 'secondary')} window.</li>
+    <li>
+        A chat section will appear in the <Badge>Info</Badge> window.
+    </li>
 </ul>

--- a/media/src/docs/HowTo.svelte
+++ b/media/src/docs/HowTo.svelte
@@ -1,52 +1,44 @@
 <script>
-    import DocImport from "./DocImport.svelte";
-    import DocKeyControls from "./DocKeyControls.svelte";
-    import DocObjParam from "./DocObjParam.svelte";
-    import DocObjWindow from "./DocObjWindow.svelte";
-    import DocPolling from "./DocPolling.svelte";
-    import DocSession from "./DocSession.svelte";
-    import Intro from "./Intro.svelte";
+    import { onMount } from 'svelte';
+    import DocImport from './DocImport.svelte';
+    import DocKeyControls from './DocKeyControls.svelte';
+    import DocObjParam from './DocObjParam.svelte';
+    import DocObjWindow from './DocObjWindow.svelte';
+    import DocPolling from './DocPolling.svelte';
+    import DocSession from './DocSession.svelte';
+    import Intro from './Intro.svelte';
 
-    let currentOption = 'Intro';
+    let currentOption = Intro;
 
     const options = [
-        'Intro', 'Objects Window', 'Special Object Parameters', 'Keyboard Controls',
-        'Importing & Formatting', 'Session', 'Polling'
-    ]
-
-    const badge = function(text, type) {
-        return '<em class="badge rounded-pill text-bg-' + type + '">' + text + '</em>';
-    }
-
+        { title: 'Intro', comp: Intro },
+        { title: 'Session Mode', comp: DocSession },
+        { title: 'Importing & Formatting', comp: DocImport },
+        { title: 'Keyboard Shortcuts', comp: DocKeyControls },
+        { title: 'Special Parameters', comp: DocObjParam },
+        { title: 'Object Window', comp: DocObjWindow },
+        { title: 'Polling', comp: DocPolling },
+    ];
 </script>
 
 <article>
-    <div class="dropdown">
-        <button class="btn btn-primary dropdown-toggle mb-2" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-            Topic: {currentOption}
-        </button>
-        <ul class="dropdown-menu">
-            {#each options as option}
-                <li>
-                    <button class="dropdown-item" on:click={() => {currentOption = option}}>{option}</button>
-                </li>
+    <div class="container">
+        <select name="some-menu" id="some-menu" bind:value={currentOption}>
+            {#each options as { title, comp }}
+                <option value={comp}>{title}</option> ]
             {/each}
-        </ul>
+        </select>
     </div>
-    {#if currentOption === 'Intro'}
-        <Intro />
-    {:else if currentOption === 'Objects Window'}
-        <DocObjWindow {badge} />
-    {:else if currentOption === 'Special Object Parameters'}
-        <DocObjParam />
-    {:else if currentOption === 'Keyboard Controls'}
-        <DocKeyControls {badge}/>
-    {:else if currentOption === 'Importing & Formatting'}
-        <DocImport />
-    {:else if currentOption === 'Session'}
-        <DocSession {badge}/>
-    {:else if currentOption === 'Polling'}
-        <DocPolling {badge}/>
-    {/if}
+
+    <svelte:component this={currentOption} />
 </article>
 
+<style>
+    select {
+        background-color: blue;
+        color: white;
+        font-size: 1.25em;
+        padding: 5px;
+        margin: 5px;
+    }
+</style>

--- a/media/src/docs/HowTo.svelte
+++ b/media/src/docs/HowTo.svelte
@@ -1,5 +1,4 @@
 <script>
-    import { onMount } from 'svelte';
     import DocImport from './DocImport.svelte';
     import DocKeyControls from './DocKeyControls.svelte';
     import DocObjParam from './DocObjParam.svelte';

--- a/media/src/docs/Intro.svelte
+++ b/media/src/docs/Intro.svelte
@@ -1,1 +1,9 @@
-Welcome to 3Demos. This is a tool dedicated to visualizations for multivariable calculus.
+<script>
+    import Badge from './Badge.svelte';
+</script>
+
+<p>Welcome to 3Demos, a tool for mathematics visualizations.</p>
+<p>
+    Click <Badge>Objects</Badge> &rarr; <Badge type="primary">Add Object</Badge>
+    below to dive right in. Else, choose a topic above to learn more.
+</p>


### PR DESCRIPTION
Addresses #486 (and closes #605). See discussion there for how I couldn't get the bootstappy dropdowns to escape their parent container. 

Here, both are swapped for old-fashioned `select` elements. There may be downsides besides being less stylable that I don't know about. Please test before merging. 

This ended with more refactoring than I expected, some like the add object code I like. Some, like the `Badge` component, less essential. 