### PR TITLE
Flash selection and autoscroll

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -50,8 +50,8 @@
         if (uuid === null) {
             selectedObjects = [];
         } else {
-            if (selectedObjects.includes(uuid)){
-                selectedObjects = selectedObjects.filter(obj => obj !== uuid);
+            if (selectedObjects.includes(uuid)) {
+                selectedObjects = selectedObjects.filter((obj) => obj !== uuid);
             } else {
                 //Can't just push. Assignment needed to trigger dynamic update
                 selectedObjects = selectedObjects.concat(uuid);
@@ -399,7 +399,8 @@
             raycaster
         );
         let nearestVisible = intersects.find(
-            intersect => intersect.object.visible && intersect.object.parent.visible
+            (intersect) =>
+                intersect.object.visible && intersect.object.parent.visible
         );
         if (nearestVisible) {
             let obj = nearestVisible.object;
@@ -415,7 +416,7 @@
     };
 
     const onDblClick = function (e) {
-        if (!e.shiftKey){
+        if (!e.shiftKey) {
             selectedObjects = [];
         }
         selectObject(hoveredObject);
@@ -492,10 +493,11 @@
                 }
                 chatBuffer = [...chatBuffer, data.message.chatMessage];
             }
-        } else if (data.message.pollResponse && (
+        } else if (
+            data.message.pollResponse &&
             // Show if I am the host, or I am a client with showPollResults
-            isHost || showPollResults
-        )) {
+            (isHost || showPollResults)
+        ) {
             const sessionKey = data.message.session_key;
             if (!(lockPoll && pollResponses[sessionKey])) {
                 if (data.message.poll === 'select point') {
@@ -532,7 +534,8 @@
             if (results && results.objects !== null) {
                 objectResponses.clear();
                 objectResponses.children = objectLoader.parse(
-                    results.objects).children;
+                    results.objects
+                ).children;
                 render();
             }
 
@@ -569,29 +572,29 @@
         if (!objects) {
             return;
         } else if (selectedObjects.length === 0) {
-            selectedObjects = [
-                objects[(moveDown ? objects.length - 1 : 0)].uuid
-            ];
+            selectedObjects = [objects[moveDown ? objects.length - 1 : 0].uuid];
         } else if (selectedObjects.length === objects.length) {
             return;
-        }else {
+        } else {
             const selectedIndex = objects
-            .map((x) => x.uuid)
-            .indexOf(selectedObjects[moveDown ? selectedObjects.length-1 : 0]);
+                .map((x) => x.uuid)
+                .indexOf(
+                    selectedObjects[moveDown ? selectedObjects.length - 1 : 0]
+                );
             const newIdx = modFloor(
                 selectedIndex + (moveDown ? -1 : 1),
                 objects.length
-                );
+            );
             if (e.shiftKey) {
-                selectedObjects = moveDown ?
-                    selectedObjects.concat([objects[newIdx].uuid]) :
-                    [objects[newIdx].uuid].concat(selectedObjects);
+                selectedObjects = moveDown
+                    ? selectedObjects.concat([objects[newIdx].uuid])
+                    : [objects[newIdx].uuid].concat(selectedObjects);
             } else {
                 selectedObjects = [objects[newIdx].uuid];
             }
         }
         render();
-    }
+    };
 
     const keyDown = (e) => {
         if (e.target.matches('input')) {

--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -233,7 +233,7 @@
         tabEl.click();
     };
 
-    const resizeObserver = new ResizeObserver(entries => {
+    const resizeObserver = new ResizeObserver((entries) => {
         for (let entry of entries) {
             if (entry && entry.contentRect && entry.contentRect.width) {
                 panelWidth = entry.contentRect.width;
@@ -798,6 +798,8 @@
         display: flex;
         flex-direction: column;
         gap: 0.25em;
+        max-height: 60vh;
+        overflow-y: auto;
     }
 
     .object-box-title {
@@ -811,5 +813,11 @@
         color: white;
         /* font-size: 1.25em; */
         padding: 5px;
+    }
+
+    .accordion-header {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+            Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',
+            sans-serif;
     }
 </style>

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -15,6 +15,7 @@
         ParametricCurve,
         checksum,
     } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
     import InputChecker from '../form-components/InputChecker.svelte';
 
     import { tickTock } from '../stores';
@@ -28,7 +29,7 @@
     export let uuid;
     export let onRenderObject = function () {};
     export let onDestroyObject = function () {};
-    export let onSelect = function() {};
+    export let onSelect = function () {};
 
     // export let paramString;
 
@@ -41,6 +42,7 @@
     };
 
     let xyz;
+    let boxItemElement;
 
     $: {
         const [x, y, z] = [params.x, params.y, params.z].map((f) =>
@@ -118,7 +120,7 @@
         side: THREE.DoubleSide,
         vertexColors: false,
         transparent: true,
-        opacity: 0.5
+        opacity: 0.5,
     });
 
     beforeUpdate(() => {
@@ -128,11 +130,6 @@
     });
     // Keep updated
     $: {
-        if (selectedObjects.length === 0 || selected) {
-            curveMaterial.opacity = 1.0;
-        } else {
-            curveMaterial.opacity = 0.1;
-        }
         curveMaterial.color.set(color);
         render();
     }
@@ -388,6 +385,11 @@
 
     $: texString1 = `${stringifyT(tau)}`;
 
+    $: if (selected && selectedObjects.length > 0) {
+        flashDance(tube, render);
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
+    }
+
     const raycaster = new THREE.Raycaster();
 
     let mouseVector = new THREE.Vector2();
@@ -411,7 +413,7 @@
         }
     };
 
-    const toggleHide = function() {
+    const toggleHide = function () {
         if (tube.visible) {
             tube.visible = false;
             circleTube.visible = false;
@@ -437,9 +439,9 @@
                     break;
                 case 'c':
                     controls.target.set(
-                    point.position.x,
-                    point.position.y,
-                    point.position.z
+                        point.position.x,
+                        point.position.y,
+                        point.position.z
                     );
                     render();
                     break;
@@ -476,8 +478,16 @@
     window.addEventListener('keyup', onKeyUp, false);
 </script>
 
-<div class={'boxItem' + (selected ? ' selected' : '')} on:keydown>
-    <ObjHeader bind:minimize bind:selectedObjects {toggleHide} {onClose} {color} {onSelect} objHidden={!tube.visible}>
+<div class="boxItem" class:selected bind:this={boxItemElement} on:keydown>
+    <ObjHeader
+        bind:minimize
+        bind:selectedObjects
+        {toggleHide}
+        {onClose}
+        {color}
+        {onSelect}
+        objHidden={!tube.visible}
+    >
         Space Curve
     </ObjHeader>
     <div hidden={minimize}>

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -6,6 +6,7 @@
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
     import { ArrowBufferGeometry, rk4, norm1, checksum } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
     import { tickTock } from '../stores';
     // import ObjectParamInput from '../form-components/ObjectParamInput.svelte';
     import InputChecker from '../form-components/InputChecker.svelte';
@@ -20,7 +21,7 @@
     export let uuid;
     export let onRenderObject = function () {};
     export let onDestroyObject = function () {};
-    export let onSelect = function() {};
+    export let onSelect = function () {};
 
     export let params = {
         p: 'y',
@@ -69,7 +70,7 @@
     const fieldMaterial = new THREE.MeshLambertMaterial({
         color,
         transparent: true,
-        opacity: 0.5
+        opacity: 0.5,
     });
     const trailMaterial = new THREE.LineBasicMaterial({
         color: 0xffffff,
@@ -80,11 +81,11 @@
     let interpretColor;
     // Keep color fresh
     $: {
-        if (selectedObjects.length === 0 || selected) {
-            fieldMaterial.opacity = 1.0;
-        } else {
-            fieldMaterial.opacity = 0.3;
-        }
+        // if (selectedObjects.length === 0 || selected) {
+        //     fieldMaterial.opacity = 1.0;
+        // } else {
+        //     fieldMaterial.opacity = 0.3;
+        // }
         fieldMaterial.color.set(color);
         const hsl = {};
         fieldMaterial.color.getHSL(hsl);
@@ -105,6 +106,13 @@
             trails.geometry.attributes.color.needsUpdate = true;
         }
         render();
+    }
+
+    let boxItemElement;
+    $: if (selected && selectedObjects.length > 0) {
+        flashDance(flowArrows.children[0], render);
+        // flashDance(trails, render); // doesn't work]]
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 
     const trailGeometry = new THREE.BufferGeometry();
@@ -359,7 +367,7 @@
         dispatch('animate');
     }
 
-    const toggleHide = function() {
+    const toggleHide = function () {
         flowArrows.visible = !flowArrows.visible;
         render();
     };
@@ -396,8 +404,16 @@
     window.addEventListener('keydown', onKeyDown, false);
 </script>
 
-<div class={'boxItem' + (selected ? ' selected' : '')} on:keydown>
-    <ObjHeader bind:minimize bind:selectedObjects {onClose} {toggleHide} objHidden={!flowArrows.visible} {color} {onSelect}>
+<div class="boxItem" class:selected bind:this={boxItemElement} on:keydown>
+    <ObjHeader
+        bind:minimize
+        bind:selectedObjects
+        {onClose}
+        {toggleHide}
+        objHidden={!flowArrows.visible}
+        {color}
+        {onSelect}
+    >
         Vector Field
     </ObjHeader>
     <div hidden={minimize}>

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -24,11 +24,12 @@
         blockGeometry,
         checksum,
     } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
 
     export let uuid;
     export let onRenderObject = function () {};
     export let onDestroyObject = function () {};
-    export let onSelect = function() {};
+    export let onSelect = function () {};
 
     export let params = {
         a: '-2',
@@ -563,11 +564,11 @@
             if (selectedObjects[selectedObjects.length - 1] === uuid) {
                 selectedPoint = point;
             }
-            plusMaterial.opacity = 0.7;
-            minusMaterial.opacity = 0.7;
+            // plusMaterial.opacity = 0.7;
+            // minusMaterial.opacity = 0.7;
         } else {
-            plusMaterial.opacity = 0.3;
-            minusMaterial.opacity = 0.3;
+            // plusMaterial.opacity = 0.3;
+            // minusMaterial.opacity = 0.3;
         }
         plusMaterial.color.set(color);
         const hsl = {};
@@ -575,6 +576,12 @@
         hsl.h = (hsl.h + 0.618033988749895) % 1;
         minusMaterial.color.setHSL(hsl.h, hsl.s, hsl.l);
         render();
+    }
+
+    let boxItemElement;
+    $: if (selected && selectedObjects.length > 0) {
+        surfaceMesh.children.map((mesh) => flashDance(mesh, render));
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 
     const update = function (dt) {
@@ -862,7 +869,7 @@
         levelReq = requestAnimationFrame(updateLevelShift);
     };
 
-    const toggleHide = function() {
+    const toggleHide = function () {
         surfaceMesh.visible = !surfaceMesh.visible;
         render();
     };
@@ -890,7 +897,7 @@
                     render();
                     break;
                 case 'Backspace':
-                    if(selected){
+                    if (selected) {
                         toggleHide();
                     }
                     break;
@@ -944,8 +951,16 @@
     window.addEventListener('keyup', onKeyUp, true);
 </script>
 
-<div class={'boxItem' + (selected ? ' selected' : '')} on:keydown>
-    <ObjHeader bind:minimize bind:selectedObjects {onClose} {toggleHide} objHidden={!surfaceMesh.visible} {color} {onSelect}>
+<div class="boxItem" class:selected bind:this={boxItemElement} on:keydown>
+    <ObjHeader
+        bind:minimize
+        bind:selectedObjects
+        {onClose}
+        {toggleHide}
+        objHidden={!surfaceMesh.visible}
+        {color}
+        {onSelect}
+    >
         Graph of function
     </ObjHeader>
     <div hidden={minimize}>
@@ -1083,7 +1098,7 @@
                     />
                 {/each}
 
-                <span class="box-1 ">
+                <span class="box-1">
                     <span class="t-box">t = {texString1}</span>
                 </span>
                 <input

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -14,11 +14,12 @@
     import { updateParams } from './levelWorker.js';
 
     import { marchingCubes, ArrowBufferGeometry, checksum } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
 
     export let uuid;
-    export let onRenderObject = function() {};
-    export let onDestroyObject = function() {};
-    export let onSelect = function() {};
+    export let onRenderObject = function () {};
+    export let onDestroyObject = function () {};
+    export let onSelect = function () {};
 
     export let params = {
         g: 'x^2 - y^2 + z^2',
@@ -75,11 +76,11 @@
             if (selectedObjects[selectedObjects.length - 1] === uuid) {
                 selectedPoint = point;
             }
-            plusMaterial.opacity = 0.7;
-            minusMaterial.opacity = 0.7;
+            // plusMaterial.opacity = 0.7;
+            // minusMaterial.opacity = 0.7;
         } else {
-            plusMaterial.opacity = 0.3;
-            minusMaterial.opacity = 0.3;
+            // plusMaterial.opacity = 0.3;
+            // minusMaterial.opacity = 0.3;
         }
         plusMaterial.color.set(color);
         const hsl = {};
@@ -87,6 +88,12 @@
         hsl.h = (hsl.h + 0.618033988749895) % 1;
         minusMaterial.color.setHSL(hsl.h, hsl.s, hsl.l);
         render();
+    }
+
+    let boxItemElement;
+    $: if (selected && selectedObjects.length > 0) {
+        mesh.children.map((mesh) => flashDance(mesh, render));
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 
     const whiteLineMaterial = new THREE.LineBasicMaterial({
@@ -364,7 +371,7 @@
         }
     };
 
-    const toggleHide = function() {
+    const toggleHide = function () {
         mesh.visible = !mesh.visible;
         render();
     };
@@ -377,7 +384,7 @@
         if (selected) {
             switch (e.key) {
                 case 'Backspace':
-                    if(selected){
+                    if (selected) {
                         toggleHide();
                     }
                     break;
@@ -430,8 +437,16 @@
     window.addEventListener('keyup', onKeyUp, false);
 </script>
 
-<div class={'boxItem' + (selected ? ' selected' : '')} on:keydown>
-    <ObjHeader bind:minimize bind:selectedObjects {onClose} {toggleHide} objHidden={!mesh.visible} {color} {onSelect}>
+<div class="boxItem" class:selected bind:this={boxItemElement} on:keydown>
+    <ObjHeader
+        bind:minimize
+        bind:selectedObjects
+        {onClose}
+        {toggleHide}
+        objHidden={!mesh.visible}
+        {color}
+        {onSelect}
+    >
         <strong>Level surface </strong>
         <span hidden={!loading}>
             <i class="fa fa-spinner fa-pulse fa-fw" />

--- a/media/src/objects/Point.svelte
+++ b/media/src/objects/Point.svelte
@@ -16,6 +16,7 @@
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
     import { checksum } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
     import InputChecker from '../form-components/InputChecker.svelte';
 
     // export let paramString;
@@ -23,7 +24,7 @@
     export let uuid;
     export let onRenderObject = function () {};
     export let onDestroyObject = function () {};
-    export let onSelect = function() {};
+    export let onSelect = function () {};
 
     export let params = {
         a: '-1',
@@ -63,7 +64,7 @@
     const pointMaterial = new THREE.MeshLambertMaterial({
         color,
         transparent: true,
-        opacity: 1.0
+        opacity: 1.0,
     });
     const point = new THREE.Mesh(
         new THREE.SphereGeometry(gridStep / 8, 16, 16),
@@ -102,13 +103,19 @@
 
     // recolor on demand
     $: {
-        if (selectedObjects.length === 0 || selected) {
-            pointMaterial.opacity = 1.0;
-        } else {
-            pointMaterial.opacity = 0.3;
-        }
+        // if (selectedObjects.length === 0 || selected) {
+        //     pointMaterial.opacity = 1.0;
+        // } else {
+        //     pointMaterial.opacity = 0.3;
+        // }
         pointMaterial.color.set(color);
         render();
+    }
+
+    let boxItemElement;
+    $: if (selected && selectedObjects.length > 0) {
+        flashDance(point, render);
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 
     onMount(() => {
@@ -125,7 +132,7 @@
         render();
     });
 
-    const toggleHide = function() {
+    const toggleHide = function () {
         point.visible = !point.visible;
         render();
     };
@@ -135,7 +142,7 @@
             return;
         }
 
-        if(selected){
+        if (selected) {
             switch (e.key) {
                 case 'Backspace':
                     toggleHide();
@@ -143,7 +150,6 @@
                 case 'p':
                     animation = !animation;
                     break;
-                        
             }
         }
     };
@@ -211,9 +217,22 @@
     }
 </script>
 
-<div class={'boxItem' + (selected ? ' selected' : '')} on:keydown
-     hidden={!show}>
-    <ObjHeader bind:minimize bind:selectedObjects {onClose} {toggleHide} objHidden={!point.visible} {color} {onSelect}>
+<div
+    class="boxItem"
+    class:selected
+    bind:this={boxItemElement}
+    on:keydown
+    hidden={!show}
+>
+    <ObjHeader
+        bind:minimize
+        bind:selectedObjects
+        {onClose}
+        {toggleHide}
+        objHidden={!point.visible}
+        {color}
+        {onSelect}
+    >
         Point <M size="sm">\langle p_1, p_2, p_3 \rangle</M>
     </ObjHeader>
     <div hidden={minimize}>
@@ -293,9 +312,9 @@
 </div>
 
 <style>
-    .dynamic-container {
+    /* .dynamic-container {
         grid-column: 0 / 5;
-    }
+    } */
     .t-box {
         display: inline-block;
         width: 40%;

--- a/media/src/objects/Solid.svelte
+++ b/media/src/objects/Solid.svelte
@@ -22,6 +22,8 @@
         SphericalSolidGeometry,
     } from '../utils.js';
 
+    import { flashDance } from '../sceneUtils';
+
     import InputChecker from '../form-components/InputChecker.svelte';
     import ColorBar from '../settings/ColorBar.svelte';
     // import ObjectParamInput from '../form-components/ObjectParamInput.svelte';
@@ -175,15 +177,21 @@
     });
 
     $: {
-        if (selectedObjects.length === 0 || selected) {
-            material.opacity = 1.0;
-            colorMaterial.opacity = 1.0;
-        } else {
-            material.opacity = 0.5;
-            colorMaterial.opacity = 0.5;
-        }
+        // if (selectedObjects.length === 0 || selected) {
+        //     material.opacity = 1.0;
+        //     colorMaterial.opacity = 1.0;
+        // } else {
+        //     material.opacity = 0.5;
+        //     colorMaterial.opacity = 0.5;
+        // }
         material.color.set(color);
         render();
+    }
+
+    let boxItemElement;
+    $: if (selected && selectedObjects.length > 0) {
+        flashDance(box, render);
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 
     const whiteLineMaterial = new THREE.LineBasicMaterial({
@@ -354,7 +362,7 @@
     render();
 </script>
 
-<div class="boxItem" class:selected on:keydown>
+<div class="boxItem" class:selected bind:this={boxItemElement} on:keydown>
     <ObjHeader
         bind:minimize
         bind:selectedObjects

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -1,7 +1,12 @@
 <script>
-    import { onMount, onDestroy, createEventDispatcher } from 'svelte';
+    import {
+        onMount,
+        onDestroy,
+        createEventDispatcher,
+        afterUpdate,
+    } from 'svelte';
     import * as THREE from 'three';
-    import { create, all } from 'mathjs';
+    import { create, all, abs } from 'mathjs';
     // import { beforeUpdate } from 'svelte';
 
     import { dependsOn } from './Vector.svelte';
@@ -216,17 +221,19 @@
         opacity: 0.7,
     });
 
+    let boxItemElement;
+
     // Keep color fresh
     $: {
         if (selectedObjects.length === 0 || selected) {
             if (selectedObjects[selectedObjects.length - 1] === uuid) {
                 selectedPoint = point;
             }
-            plusMaterial.opacity = 0.7;
-            minusMaterial.opacity = 0.7;
+            // plusMaterial.opacity = 0.7;
+            // minusMaterial.opacity = 0.7;
         } else {
-            plusMaterial.opacity = 0.3;
-            minusMaterial.opacity = 0.3;
+            // plusMaterial.opacity = 0.3;
+            // minusMaterial.opacity = 0.3;
         }
         plusMaterial.color.set(color);
         const hsl = {};
@@ -584,6 +591,46 @@
         render();
     });
 
+    const flashDance = (mesh) => {
+        // console.log(mesh);
+        const mat = mesh.material;
+        const color = mat.color;
+        const newcol = {};
+        color.getHSL(newcol);
+        const oo = mat.opacity;
+        let t = 0;
+        let last = null;
+        let req;
+        let animate = (time) => {
+            if (last === null) {
+                t = 0;
+            } else {
+                t += (time - last) / 400;
+            }
+            const T = (Math.pow(1 - abs(4 * abs(1 / 2 - t) - 1), 2) * 2) / 3;
+            last = time;
+            color.setHSL(newcol.h, newcol.s, (1 - T) * newcol.l + T);
+            mat.opacity = (1 - T) * oo + T;
+            if (t >= 1) {
+                t = 0;
+                last = null;
+                // mat.opacity = oo;
+                // color.setHSL(newcol.h, newcol.s, newcol.l);
+            } else {
+                cancelAnimationFrame(req);
+                req = requestAnimationFrame(animate);
+            }
+            render();
+        };
+
+        requestAnimationFrame(animate);
+    };
+
+    $: if (selected) {
+        surfaceMesh.children.map(flashDance);
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
+    }
+
     // Select a point
     const tanFrame = new THREE.Object3D();
     const arrows = {
@@ -830,7 +877,7 @@
     window.addEventListener('keyup', onKeyUp, false);
 </script>
 
-<div class="boxItem" class:selected on:keydown>
+<div class="boxItem" class:selected on:keydown bind:this={boxItemElement}>
     <ObjHeader
         bind:minimize
         bind:selectedObjects

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -1,7 +1,7 @@
 <script>
     import { onMount, onDestroy, createEventDispatcher } from 'svelte';
     import * as THREE from 'three';
-    import { create, all, abs } from 'mathjs';
+    import { create, all } from 'mathjs';
     // import { beforeUpdate } from 'svelte';
 
     import { dependsOn } from './Vector.svelte';
@@ -25,6 +25,7 @@
         checksum,
         ParametricGeometry,
     } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
     import InputChecker from '../form-components/InputChecker.svelte';
     import ColorBar from '../settings/ColorBar.svelte';
 
@@ -586,43 +587,43 @@
         render();
     });
 
-    const flashDance = (mesh) => {
-        // console.log(mesh);
-        const mat = mesh.material;
-        const color = mat.color;
-        const newcol = {};
-        color.getHSL(newcol);
-        const oo = mat.opacity;
-        let t = 0;
-        let last = null;
-        let req;
-        let animate = (time) => {
-            if (last === null) {
-                t = 0;
-            } else {
-                t += (time - last) / 400;
-            }
-            const T = (Math.pow(1 - abs(4 * abs(1 / 2 - t) - 1), 2) * 2) / 3;
-            last = time;
-            color.setHSL(newcol.h, newcol.s, (1 - T) * newcol.l + T);
-            mat.opacity = (1 - T) * oo + T;
-            if (t >= 1) {
-                t = 0;
-                last = null;
-                // mat.opacity = oo;
-                // color.setHSL(newcol.h, newcol.s, newcol.l);
-            } else {
-                cancelAnimationFrame(req);
-                req = requestAnimationFrame(animate);
-            }
-            render();
-        };
+    // const flashDance = (mesh, render=render) => {
+    //     // console.log(mesh);
+    //     const mat = mesh.material;
+    //     const color = mat.color;
+    //     const newcol = {};
+    //     color.getHSL(newcol);
+    //     const oo = mat.opacity;
+    //     let t = 0;
+    //     let last = null;
+    //     let req;
+    //     let animate = (time) => {
+    //         if (last === null) {
+    //             t = 0;
+    //         } else {
+    //             t += (time - last) / 400;
+    //         }
+    //         const T = ((1 / 2 - Math.cos(2 * Math.PI * t) / 2) * 3) / 4;
+    //         last = time;
+    //         color.setHSL(newcol.h, newcol.s, (1 - T) * newcol.l + T);
+    //         mat.opacity = (1 - T) * oo + T;
+    //         if (t >= 1) {
+    //             t = 0;
+    //             last = null;
+    //             // mat.opacity = oo;
+    //             // color.setHSL(newcol.h, newcol.s, newcol.l);
+    //         } else {
+    //             cancelAnimationFrame(req);
+    //             req = requestAnimationFrame(animate);
+    //         }
+    //         render();
+    //     };
 
-        requestAnimationFrame(animate);
-    };
+    //     requestAnimationFrame(animate);
+    // };
 
     $: if (selected && selectedObjects.length > 0) {
-        surfaceMesh.children.map(flashDance);
+        surfaceMesh.children.map((mesh) => flashDance(mesh, render));
         boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -1,10 +1,5 @@
 <script>
-    import {
-        onMount,
-        onDestroy,
-        createEventDispatcher,
-        afterUpdate,
-    } from 'svelte';
+    import { onMount, onDestroy, createEventDispatcher } from 'svelte';
     import * as THREE from 'three';
     import { create, all, abs } from 'mathjs';
     // import { beforeUpdate } from 'svelte';

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -621,7 +621,7 @@
         requestAnimationFrame(animate);
     };
 
-    $: if (selected) {
+    $: if (selected && selectedObjects.length > 0) {
         surfaceMesh.children.map(flashDance);
         boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -28,12 +28,13 @@
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
     import { ArrowBufferGeometry, checksum } from '../utils.js';
+    import { flashDance } from '../sceneUtils';
     import InputChecker from '../form-components/InputChecker.svelte';
 
     export let uuid;
     export let onRenderObject = function () {};
     export let onDestroyObject = function () {};
-    export let onSelect = function() {};
+    export let onSelect = function () {};
 
     export let params = {
         a: '-1',
@@ -156,13 +157,14 @@
 
     // recolor on demand
     $: {
-        if ( selectedObjects.length === 0 || selected) {
-            arrowMaterial.opacity = 1.0;
-        } else {
-            arrowMaterial.opacity = 0.3;
-        }
         arrowMaterial.color.set(color);
         render();
+    }
+
+    let boxItemElement;
+    $: if (selected && selectedObjects.length > 0) {
+        flashDance(arrow, render);
+        boxItemElement.scrollIntoView({ behavior: 'smooth' });
     }
 
     onMount(() => {
@@ -182,7 +184,7 @@
         render();
     });
 
-    const toggleHide = function() {
+    const toggleHide = function () {
         arrow.visible = !arrow.visible;
         render();
     };
@@ -278,11 +280,21 @@
 </script>
 
 <div
-    class={'boxItem' + (selected ? ' selected' : '')}
+    class="boxItem"
+    class:selected
+    bind:this={boxItemElement}
     hidden={!show}
     on:keydown
 >
-    <ObjHeader bind:minimize bind:selectedObjects {onClose} {toggleHide} objHidden={!arrow.visible} {color} {onSelect}>
+    <ObjHeader
+        bind:minimize
+        bind:selectedObjects
+        {onClose}
+        {toggleHide}
+        objHidden={!arrow.visible}
+        {color}
+        {onSelect}
+    >
         Vector <M size="sm">\langle v_1, v_2, v_3 \rangle</M>
     </ObjHeader>
     <div hidden={minimize}>
@@ -385,9 +397,9 @@
 </div>
 
 <style>
-    .dynamic-container {
+    /* .dynamic-container {
         grid-column: 0 / 5;
-    }
+    } */
     input.form-control {
         color: black;
     }

--- a/media/src/sceneUtils.js
+++ b/media/src/sceneUtils.js
@@ -114,8 +114,50 @@ const findPointerIntersects = function (objects, pointer, camera, raycaster) {
     return intersects;
 };
 
+/**
+ * "Flash" the object by animating its color to opaque white and back.
+ * @param {THREE.Object3D} mesh 
+ * @param {function} render 
+ */
+const flashDance = (mesh, render) => {
+    // console.log(mesh);
+    const mat = mesh.material;
+    const color = mat.color;
+    const newcol = {};
+    color.getHSL(newcol);
+    const oo = mat.opacity;
+    let t = 0;
+    let last = null;
+    let req;
+    let animate = (time) => {
+        if (last === null) {
+            t = 0;
+        } else {
+            t += (time - last) / 400;
+        }
+        const T = ((1 / 2 - Math.cos(2 * Math.PI * t) / 2) * 3) / 4;
+        last = time;
+        color.setHSL(newcol.h, newcol.s, (1 - T) * newcol.l + T);
+        mat.opacity = (1 - T) * oo + T;
+        if (t >= 1) {
+            t = 0;
+            last = null;
+            mat.opacity = oo;
+            color.setHSL(newcol.h, newcol.s, newcol.l);
+        } else {
+            cancelAnimationFrame(req);
+            req = requestAnimationFrame(animate);
+        }
+        render();
+    };
+
+    requestAnimationFrame(animate);
+};
+
+
 export {
     makeObject,
+    flashDance,
     removeObject,
     updateObject,
     publishScene,


### PR DESCRIPTION
In an attempt to close #425, I started messing around with the selection indication. Here is a temporary "flash" of the objects. ~This only is applied to `surface` objects at the moment,~ so add a few and play with selecting different combinations. 

Looks smoother in rendering than in the gif below. Do note the autoscrolling objects window. 

![select-flash](https://github.com/ccnmtl/3demos/assets/19934878/9e1c9568-99db-40f3-9fb3-38ce0a5ea52f)

TODO:
  - ~Play with the timing/intensity (consider epilepsy)~
  - ~Reflash on duplicate/multiple selection (right now just reactive to `selected` being set to `true` in the component).~
  - ~Add to other objects~
