### PR TITLE
Enumerate titles

### DIFF
--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -476,7 +476,7 @@
 
                         <div class="objectBoxInner">
                             <!-- Main Loop, if you will -->
-                            {#each objects as { uuid, kind, params, color, animation } (uuid)}
+                            {#each objects as { uuid, kind, params, color, title, animation } (uuid)}
                                 <div
                                     transition:slide={{
                                         delay: 0,
@@ -504,6 +504,7 @@
                                                 );
                                         }}
                                         bind:color
+                                        bind:title
                                         bind:animation
                                         {uuid}
                                         {gridStep}

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-    let i = 0;
+    let titleIndex = 0;
 </script>
 
 <script>
@@ -31,6 +31,7 @@
 
     const dispatch = createEventDispatcher();
 
+    export let title;
     export let uuid;
     export let onRenderObject = function () {};
     export let onDestroyObject = function () {};
@@ -45,8 +46,6 @@
         y: 't^2',
         z: 't^3',
     };
-
-    i++;
 
     let xyz;
     let boxItemElement;
@@ -365,6 +364,8 @@
             frame.visible = true;
             dispatch('animate');
         }
+        titleIndex++;
+        title = title || `Space Curve ${titleIndex}`;
     });
     onDestroy(() => {
         onDestroyObject(tube);
@@ -495,7 +496,7 @@
         {onSelect}
         objHidden={!tube.visible}
     >
-        <Nametag title={`Space Curve ${i}`} />
+        <Nametag bind:title />
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -366,6 +366,9 @@
         }
         titleIndex++;
         title = title || `Space Curve ${titleIndex}`;
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
     onDestroy(() => {
         onDestroyObject(tube);

--- a/media/src/objects/Curve.svelte
+++ b/media/src/objects/Curve.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+    let i = 0;
+</script>
+
 <script>
     import {
         onMount,
@@ -5,6 +9,7 @@
         createEventDispatcher,
         beforeUpdate,
     } from 'svelte';
+    import Nametag from './Nametag.svelte';
     import * as THREE from 'three';
     import { create, all } from 'mathjs';
 
@@ -40,6 +45,8 @@
         y: 't^2',
         z: 't^3',
     };
+
+    i++;
 
     let xyz;
     let boxItemElement;
@@ -488,7 +495,7 @@
         {onSelect}
         objHidden={!tube.visible}
     >
-        Space Curve
+        <Nametag title={`Space Curve ${i}`} />
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+    let titleIndex = 0;
+</script>
+
 <script>
     import { onMount, onDestroy, createEventDispatcher } from 'svelte';
     import * as THREE from 'three';
@@ -5,6 +9,7 @@
 
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
+    import Nametag from './Nametag.svelte';
     import { ArrowBufferGeometry, rk4, norm1, checksum } from '../utils.js';
     import { flashDance } from '../sceneUtils';
     import { tickTock } from '../stores';
@@ -43,6 +48,7 @@
     export let selectedObjects;
     export let selected;
     export let color = '#373765';
+    export let title;
 
     let minimize = false;
     let flowTrails = true;
@@ -326,6 +332,9 @@
     scene.add(trails);
 
     onMount(() => {
+        titleIndex++;
+        title = title || `Vector Field ${titleIndex}`;
+
         updateField();
         maxLength = initFlowArrows(flowArrows, gridMax, params.nVec);
         updateFlowArrows(flowArrows, fieldF, 0);
@@ -414,7 +423,7 @@
         {color}
         {onSelect}
     >
-        Vector Field
+        <Nametag bind:title />
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Field.svelte
+++ b/media/src/objects/Field.svelte
@@ -340,6 +340,9 @@
         updateFlowArrows(flowArrows, fieldF, 0);
         render();
         if (animation) dispatch('animate');
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
     onDestroy(() => {
         onDestroyObject(flowArrows);

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -820,6 +820,9 @@
         updateSurface();
         updateBoxes();
         if (animation) dispatch('animate');
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
     onDestroy(() => {
         onDestroyObject(...surfaceMesh.children);

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+    let titleIndex = 0;
+</script>
+
 <script>
     import { onMount, onDestroy, createEventDispatcher } from 'svelte';
     import * as THREE from 'three';
@@ -6,6 +10,7 @@
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
     import InputChecker from '../form-components/InputChecker.svelte';
+    import Nametag from './Nametag.svelte';
     import PlayButtons from '../form-components/PlayButtons.svelte';
     import { dependsOn } from './Vector.svelte';
     import { tickTock } from '../stores';
@@ -105,6 +110,7 @@
     export let selected;
     export let selectedObjects;
     export let selectedPoint;
+    export let title;
 
     let minimize = false;
 
@@ -806,6 +812,9 @@
     };
 
     onMount(() => {
+        titleIndex++;
+        title = title || `Graph ${titleIndex}`;
+
         params.t0 = params.t0 || '0';
         params.t1 = params.t1 || '1';
         updateSurface();
@@ -961,7 +970,7 @@
         {color}
         {onSelect}
     >
-        Graph of function
+        <Nametag bind:title />
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -1,10 +1,15 @@
+<script context="module">
+    let titleIndex = 0;
+</script>
+
 <script>
-    import { onDestroy } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
     import * as THREE from 'three';
     import { create, all } from 'mathjs';
 
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
+    import Nametag from './Nametag.svelte';
     import ObjectParamInput from '../form-components/ObjectParamInput.svelte';
     import InputChecker from '../form-components/InputChecker.svelte';
 
@@ -38,6 +43,7 @@
     export let selected;
     export let selectedObjects;
     export let selectedPoint;
+    export let title;
 
     export let camera,
         controls,
@@ -218,6 +224,10 @@
         loading = false;
         render();
     };
+    onMount(() => {
+        titleIndex++;
+        title = title || `Level Surface ${titleIndex}`;
+    });
 
     onDestroy(() => {
         onDestroyObject(...mesh.children);
@@ -447,7 +457,7 @@
         {color}
         {onSelect}
     >
-        <strong>Level surface </strong>
+        <Nametag bind:title />
         <span hidden={!loading}>
             <i class="fa fa-spinner fa-pulse fa-fw" />
             <span class="sr-only">Loading...</span>

--- a/media/src/objects/Level.svelte
+++ b/media/src/objects/Level.svelte
@@ -227,6 +227,9 @@
     onMount(() => {
         titleIndex++;
         title = title || `Level Surface ${titleIndex}`;
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
 
     onDestroy(() => {

--- a/media/src/objects/Nametag.svelte
+++ b/media/src/objects/Nametag.svelte
@@ -1,0 +1,68 @@
+<script>
+    import { e } from 'mathjs';
+
+    export let title;
+
+    let edit = false;
+    let backupTitle;
+    let editBar;
+
+    const init = (el) => {
+        el.focus();
+        el.select();
+        backupTitle = el.value;
+    };
+</script>
+
+{#if edit}
+    <input
+        type="text"
+        bind:this={editBar}
+        bind:value={title}
+        use:init
+        on:keydown={(e) => {
+            if (e.key === 'Escape') {
+                console.log(e.key);
+                title = backupTitle;
+                edit = false;
+                e.stopPropagation();
+            } else {
+                if (e.key === 'Enter') {
+                    edit = false;
+                }
+            }
+        }}
+        on:blur={() => {
+            edit = false;
+        }}
+        on:change={() => {
+            edit = false;
+        }}
+        on:click={(e) => e.stopPropagation()}
+    />
+{:else}
+    <strong
+        ><span class="edit-hover">
+            {title}&nbsp;
+            <a
+                href={'#'}
+                on:click|preventDefault={(e) => {
+                    edit = true;
+                    e.stopPropagation();
+                }}
+            >
+                <i class="bi bi-pencil-square" /></a
+            ></span
+        >
+    </strong>
+{/if}
+
+<style>
+    .edit-hover a {
+        visibility: hidden;
+    }
+
+    .edit-hover:hover a {
+        visibility: visible;
+    }
+</style>

--- a/media/src/objects/Nametag.svelte
+++ b/media/src/objects/Nametag.svelte
@@ -1,6 +1,4 @@
 <script>
-    import { e } from 'mathjs';
-
     export let title;
 
     let edit = false;

--- a/media/src/objects/ObjHeader.svelte
+++ b/media/src/objects/ObjHeader.svelte
@@ -4,8 +4,8 @@
     export let color;
     export let objHidden = null;
     export let selectedObjects;
-    export let onSelect = function() {};
-    export let toggleHide = function() {};
+    export let onSelect = function () {};
+    export let toggleHide = function () {};
 </script>
 
 <div class="box-title">
@@ -13,35 +13,41 @@
         <strong style="color: {color};">
             <i class="fa fa-square" />
         </strong>
-        <a href={'#'} class="link-light"
-           title="Select object"
-           on:click|preventDefault={(e) => {
+        <a
+            href={'#'}
+            class="link-light"
+            title="Select object"
+            on:click|preventDefault={(e) => {
                 if (e.shiftKey) {
                     onSelect();
                 } else {
                     selectedObjects = [];
-                    onSelect()
-                }}}>
-            <slot></slot>
+                    onSelect();
+                }
+            }}
+        >
+            <slot />
         </a>
     </span>
     <div class="item-header">
         {#if objHidden != null}
             <button
                 title={(objHidden ? 'Show' : 'Hide') + 'object'}
-                on:click={toggleHide}>
-                <i class={'fa fa-eye' + (objHidden ? '-slash' : '')}></i>
+                on:click={toggleHide}
+            >
+                <i class={'fa fa-eye' + (objHidden ? '-slash' : '')} />
             </button>
         {/if}
         <button
             title={(minimize ? 'Reveal ' : 'Collapse ') + 'object parameters'}
-            on:click={() => {minimize = !minimize}}>
-            <i class="fa fa-window-minimize"></i>
+            on:click={() => {
+                minimize = !minimize;
+            }}
+        >
+            <i class="fa fa-window-minimize" />
         </button>
-        <button
-            title="Remove object"
-            on:click={onClose}>
-            <i class="fa fa-window-close"></i>
+        <button title="Remove object" on:click={onClose}>
+            <i class="fa fa-window-close" />
         </button>
     </div>
 </div>

--- a/media/src/objects/Point.svelte
+++ b/media/src/objects/Point.svelte
@@ -126,6 +126,9 @@
         if (animation) dispatch('animate');
         titleIndex++;
         title = title || `Point ${titleIndex}`;
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
     onDestroy(() => {
         onDestroyObject(point);

--- a/media/src/objects/Point.svelte
+++ b/media/src/objects/Point.svelte
@@ -4,6 +4,8 @@
     const math = create(all, config);
 
     import { dependsOn } from './Vector.svelte';
+
+    let titleIndex = 0;
 </script>
 
 <script>
@@ -18,6 +20,7 @@
     import { checksum } from '../utils.js';
     import { flashDance } from '../sceneUtils';
     import InputChecker from '../form-components/InputChecker.svelte';
+    import Nametag from './Nametag.svelte';
 
     // export let paramString;
 
@@ -33,6 +36,7 @@
     };
 
     export let color = '#FFFF33';
+    export let title;
 
     // useless code to suppress dev warnings
     export let camera;
@@ -120,6 +124,8 @@
 
     onMount(() => {
         if (animation) dispatch('animate');
+        titleIndex++;
+        title = title || `Point ${titleIndex}`;
     });
     onDestroy(() => {
         onDestroyObject(point);
@@ -233,7 +239,8 @@
         {color}
         {onSelect}
     >
-        Point <M size="sm">\langle p_1, p_2, p_3 \rangle</M>
+        <Nametag bind:title />
+        <M size="sm">\langle p_1, p_2, p_3 \rangle</M>
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Solid.svelte
+++ b/media/src/objects/Solid.svelte
@@ -1,5 +1,9 @@
+<script context="module">
+    let titleIndex = 0;
+</script>
+
 <script>
-    import { onDestroy } from 'svelte';
+    import { onMount, onDestroy } from 'svelte';
     import * as THREE from 'three';
     import { create, all } from 'mathjs';
 
@@ -26,6 +30,7 @@
 
     import InputChecker from '../form-components/InputChecker.svelte';
     import ColorBar from '../settings/ColorBar.svelte';
+    import Nametag from './Nametag.svelte';
     // import ObjectParamInput from '../form-components/ObjectParamInput.svelte';
 
     export let uuid;
@@ -33,7 +38,10 @@
     export let onDestroyObject = function () {};
     export let onSelect = function () {};
 
-    // onMount(onRenderObject);
+    onMount(() => {
+        titleIndex++;
+        title = title || `Solid Region ${titleIndex}`;
+    });
     onDestroy(() => {
         scene.remove(solidGroup);
         box.geometry.dispose();
@@ -90,6 +98,7 @@
 
     let minimize = false;
     export let color = '#5432ff';
+    export let title;
     // export let animation = false;
 
     let nX = 60;
@@ -370,7 +379,7 @@
         {toggleHide}
         objHidden={!solidGroup.visible}
         {color}
-        {onSelect}>Solid Region</ObjHeader
+        {onSelect}><Nametag bind:title /></ObjHeader
     >
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Solid.svelte
+++ b/media/src/objects/Solid.svelte
@@ -41,6 +41,8 @@
     onMount(() => {
         titleIndex++;
         title = title || `Solid Region ${titleIndex}`;
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
     onDestroy(() => {
         scene.remove(solidGroup);
@@ -200,7 +202,8 @@
     let boxItemElement;
     $: if (selected && selectedObjects.length > 0) {
         flashDance(box, render);
-        boxItemElement.scrollIntoView({ behavior: 'smooth' });
+        boxItemElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        // console.log("I am scroll into view, I can't think of nothin' else.");
     }
 
     const whiteLineMaterial = new THREE.LineBasicMaterial({

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -581,6 +581,9 @@
         params.t1 = params.t1 || '1';
         // updateSurface();
         if (animation) dispatch('animate');
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
 
     onDestroy(() => {
@@ -595,41 +598,6 @@
         window.removeEventListener('keyup', onKeyUp, false);
         render();
     });
-
-    // const flashDance = (mesh, render=render) => {
-    //     // console.log(mesh);
-    //     const mat = mesh.material;
-    //     const color = mat.color;
-    //     const newcol = {};
-    //     color.getHSL(newcol);
-    //     const oo = mat.opacity;
-    //     let t = 0;
-    //     let last = null;
-    //     let req;
-    //     let animate = (time) => {
-    //         if (last === null) {
-    //             t = 0;
-    //         } else {
-    //             t += (time - last) / 400;
-    //         }
-    //         const T = ((1 / 2 - Math.cos(2 * Math.PI * t) / 2) * 3) / 4;
-    //         last = time;
-    //         color.setHSL(newcol.h, newcol.s, (1 - T) * newcol.l + T);
-    //         mat.opacity = (1 - T) * oo + T;
-    //         if (t >= 1) {
-    //             t = 0;
-    //             last = null;
-    //             // mat.opacity = oo;
-    //             // color.setHSL(newcol.h, newcol.s, newcol.l);
-    //         } else {
-    //             cancelAnimationFrame(req);
-    //             req = requestAnimationFrame(animate);
-    //         }
-    //         render();
-    //     };
-
-    //     requestAnimationFrame(animate);
-    // };
 
     $: if (selected && selectedObjects.length > 0) {
         surfaceMesh.children.map((mesh) => flashDance(mesh, render));

--- a/media/src/objects/Surface.svelte
+++ b/media/src/objects/Surface.svelte
@@ -1,3 +1,7 @@
+<script context="module">
+    let titleIndex = 0;
+</script>
+
 <script>
     import { onMount, onDestroy, createEventDispatcher } from 'svelte';
     import * as THREE from 'three';
@@ -7,6 +11,7 @@
     import { dependsOn } from './Vector.svelte';
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
+    import Nametag from './Nametag.svelte';
     import PlayButtons from '../form-components/PlayButtons.svelte';
     import { densityColormap, tickTock, vMax, vMin } from '../stores';
 
@@ -46,6 +51,7 @@
         t1: '1',
     };
     export let color = '#3232ff';
+    export let title;
 
     export let animation = false;
 
@@ -568,6 +574,9 @@
 
     // onMount(updateSurface);
     onMount(() => {
+        titleIndex++;
+        title = title || `Parametric Surface ${titleIndex}`;
+
         params.t0 = params.t0 || '0';
         params.t1 = params.t1 || '1';
         // updateSurface();
@@ -883,7 +892,7 @@
         {color}
         {onSelect}
     >
-        Parametric surface
+        <Nametag bind:title />
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -175,6 +175,9 @@
         titleIndex++;
         title = title || `Vector ${titleIndex}`;
         if (animation) dispatch('animate');
+
+        selectedObjects = [];
+        setTimeout(onSelect, 350);
     });
     onDestroy(() => {
         onDestroyObject(arrows);

--- a/media/src/objects/Vector.svelte
+++ b/media/src/objects/Vector.svelte
@@ -17,6 +17,8 @@
                 });
                 return nodes.some((node) => node.name === ch);
             });
+
+    let titleIndex = 0;
 </script>
 
 <script>
@@ -27,6 +29,7 @@
     import PlayButtons from '../form-components/PlayButtons.svelte';
     import M from '../M.svelte';
     import ObjHeader from './ObjHeader.svelte';
+    import Nametag from './Nametag.svelte';
     import { ArrowBufferGeometry, checksum } from '../utils.js';
     import { flashDance } from '../sceneUtils';
     import InputChecker from '../form-components/InputChecker.svelte';
@@ -63,6 +66,7 @@
     export let animation = false;
     export let selected;
     export let selectedObjects;
+    export let title;
 
     let minimize = false;
 
@@ -168,6 +172,8 @@
     }
 
     onMount(() => {
+        titleIndex++;
+        title = title || `Vector ${titleIndex}`;
         if (animation) dispatch('animate');
     });
     onDestroy(() => {
@@ -295,7 +301,8 @@
         {color}
         {onSelect}
     >
-        Vector <M size="sm">\langle v_1, v_2, v_3 \rangle</M>
+        <Nametag bind:title />
+        <M size="sm">\langle v_1, v_2, v_3 \rangle</M>
     </ObjHeader>
     <div hidden={minimize}>
         <div class="threedemos-container container">


### PR DESCRIPTION
Introduces a `title` property for 3Demos objects, displayed on the panel. Numbered sequentially (on each type) by default, but editable via a hover. 

Worth checking that selection isn't broken somewhere. 