### PR TITLE
Update documentation for menu hiding

### DIFF
--- a/media/src/docs/DocKeyControls.svelte
+++ b/media/src/docs/DocKeyControls.svelte
@@ -5,7 +5,7 @@
 
 <ul>
     <li>
-        <Badge>Esc</Badge>
+        <Badge>h</Badge>
         Hide/Show the MENU
     </li>
     <li>


### PR DESCRIPTION
The Escape key was remapped to 'h' to toggle the panel, here: https://github.com/ccnmtl/3demos/pull/621/files#diff-2235248ad737318f83b794277a0d675ea193e27942e1d9913c21de6f17f791b0R292