### PR TITLE
Fix joinUrl calls

### DIFF
--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -316,7 +316,7 @@
         <a href="/" title="Home" class="demos-logo">
             <img
                 alt="3Demos logo"
-                src={joinUrl(window.STATIC_PREFIX, '/3demos-logo.svg')}
+                src={joinUrl(window.STATIC_PREFIX, './3demos-logo.svg')}
             />
         </a>
 

--- a/media/src/docs/About.svelte
+++ b/media/src/docs/About.svelte
@@ -64,12 +64,12 @@
         performance.
     </p>
     <a href="https://www.engineering.columbia.edu/" target="_blank" itemprop="url" title="The Fu Foundation School of Engineering and Applied Science">
-        <img class="logo" src={joinUrl(window.STATIC_PREFIX, '/logo-seas.jpg')} alt="SEAS logo" itemprop="logo">
+        <img class="logo" src={joinUrl(window.STATIC_PREFIX, './logo-seas.jpg')} alt="SEAS logo" itemprop="logo">
         <span class="sr-only" itemprop="name">The Fu Foundation School of Engineering and Applied Science</span>
     </a>
     <a href="https://ctl.columbia.edu" title="Columbia University Center for Teaching and Learning"
         target="_blank" itemprop="url">
-        <img class="logo" src={joinUrl(window.STATIC_PREFIX, '/logo-ctl.png')} alt="CTL logo" itemprop="logo" style="margin-top: 10px;">
+        <img class="logo" src={joinUrl(window.STATIC_PREFIX, './logo-ctl.png')} alt="CTL logo" itemprop="logo" style="margin-top: 10px;">
         <span class="sr-only" itemprop="name">Center for Teaching and Learning at Columbia University</span>
     </a>
 </article>


### PR DESCRIPTION
It looks like these need to start with `./` to get the path correct. This could be documented better.. or the behavior of the function changed. Not a high priority, though.