### PR TITLE
remove invalid css setting: "font: 1.2rem"

### DIFF
--- a/media/mathplayground/global.css
+++ b/media/mathplayground/global.css
@@ -11,7 +11,6 @@ article {
     color: white;
     background-color: rgba(0, 0, 0, 0.5);
     padding: 1rem;
-    font: 1.2rem;
     border-radius: 0.5rem;
 }
 


### PR DESCRIPTION
I think the intention here was to set the font-size to 1.2rem. But default font size should generally be left up to the browser, as this makes things more flexible and customizable. See: https://getbootstrap.com/docs/5.2/content/typography/