### PR TITLE
Remove django-cacheds3storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ daphne==4.0.0
 Deprecated==1.2.13
 Django==4.2.3
 django_statsd_mozilla==0.4.0
-django-cacheds3storage==0.3.0
 django-smoketest==1.2.0
 django-storages==1.13.1
 django-ga-context==0.1.0


### PR DESCRIPTION
This library is unnecessary with newer versions of django-storages.