### PR TITLE
Check axes labels in animate loop

### DIFF
--- a/media/src/App.svelte
+++ b/media/src/App.svelte
@@ -295,6 +295,11 @@
             scaleUpdate(dt);
         }
 
+        for (let index = 0; index < axesText.length; index++) {
+            const element = axesText[index];
+            element.lookAt(currentCamera.position);
+        }
+
         currentControls?.update();
         renderer.render(scene, currentCamera);
         if (debug) {


### PR DESCRIPTION
Closes #898.
Animate loop was doing its own render without checking camera position. Could alter this to check if camera position has actually changed, but few enough labels to notice the difference at this point. 