### PR TITLE
Configure log rotation

### DIFF
--- a/mathplayground/settings_production.py
+++ b/mathplayground/settings_production.py
@@ -31,7 +31,9 @@ LOGGING = {
     'handlers': {
         'file': {
             'level': 'INFO',
-            'class': 'logging.FileHandler',
+            'class': 'logging.RotatingFileHandler',
+            'backupCount': 4,
+            'maxBytes': 10*1024*1024,
             'filename': '/var/log/django/' + project + '.log',
         },
     },

--- a/mathplayground/settings_staging.py
+++ b/mathplayground/settings_staging.py
@@ -29,7 +29,9 @@ LOGGING = {
     'handlers': {
         'file': {
             'level': 'INFO',
-            'class': 'logging.FileHandler',
+            'class': 'logging.RotatingFileHandler',
+            'backupCount': 4,
+            'maxBytes': 10*1024*1024,
             'filename': '/var/log/django/' + project + '.log',
         },
     },


### PR DESCRIPTION
Rotate django logs when they meet 10mb.

Based on:
https://github.com/ccnmtl/ctlsettings/pull/24