### PR TITLE
Update logging --> logging.handlers

### DIFF
--- a/mathplayground/settings_production.py
+++ b/mathplayground/settings_production.py
@@ -31,7 +31,7 @@ LOGGING = {
     'handlers': {
         'file': {
             'level': 'INFO',
-            'class': 'logging.RotatingFileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'backupCount': 4,
             'maxBytes': 10*1024*1024,
             'filename': '/var/log/django/' + project + '.log',

--- a/mathplayground/settings_staging.py
+++ b/mathplayground/settings_staging.py
@@ -29,7 +29,7 @@ LOGGING = {
     'handlers': {
         'file': {
             'level': 'INFO',
-            'class': 'logging.RotatingFileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'backupCount': 4,
             'maxBytes': 10*1024*1024,
             'filename': '/var/log/django/' + project + '.log',


### PR DESCRIPTION
3Demos might be running on a newer version of Python than ctlsettings. The Jenkins build could not find the `logging.RotatingFileHandler` so I've updated it to `logging.handlers.RotatingFileHandler` according to the current Python documentation. 