### PR TITLE
Migrate to Svelte 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 .pyre/
 
 ve/
+
+# ignore IDE files
+.idea/

--- a/media/src/Panel.svelte
+++ b/media/src/Panel.svelte
@@ -7,7 +7,7 @@
     import { quintOut } from 'svelte/easing';
     // import { flip } from 'svelte/animate';
 
-    import { TabContent, TabPane } from 'sveltestrap';
+    import { TabContent, TabPane } from '@sveltestrap/sveltestrap';
 
     import HowTo from './docs/HowTo.svelte';
     import About from './docs/About.svelte';
@@ -542,7 +542,7 @@
                                     <!-- Main Loop, if you will -->
                                     {#each $demoObjects as { uuid, kind, params, color, title, animation, ...etc } (uuid)}
                                         <div
-                                            transition:slide={{
+                                            transition:slide|global={{
                                                 delay: 0,
                                                 duration: 200,
                                                 easing: quintOut,

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -1104,7 +1104,7 @@
             </label>
 
             {#if isDynamic}
-                <!-- <div class="dynamic-container" transition:slide> -->
+                <!-- <div class="dynamic-container" transition:slide|global> -->
                 {#each ['t0', 't1'] as name}
                     {#if name === 't1'}
                         <span class="box box-3"

--- a/media/src/objects/Point.svelte
+++ b/media/src/objects/Point.svelte
@@ -289,7 +289,7 @@
             {/each}
 
             {#if isDynamic}
-                <!-- <div class="dynamic-container" transition:slide> -->
+                <!-- <div class="dynamic-container" transition:slide|global> -->
                 {#each ['t0', 't1'] as name}
                     {#if name === 't1'}
                         <span class="box box-3"

--- a/media/src/polls/Polls.svelte
+++ b/media/src/polls/Polls.svelte
@@ -1,5 +1,5 @@
 <script>
-    import { TabContent, TabPane } from 'sveltestrap';
+    import { TabContent, TabPane } from '@sveltestrap/sveltestrap';
     import PollResponses from './PollResponses.svelte';
     import PollForm from './PollForm.svelte';
     import { Poll, setIdCounter } from './Poll.js';
@@ -99,7 +99,7 @@
         // https://github.com/bestguy/sveltestrap/issues/485
         const responsesEl = querySelectorIncludesText(
             '.polls-modal .nav-tabs a',
-            'Responses'
+            'Responses',
         );
         responsesEl.click();
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5281,9 +5281,9 @@
       }
     },
     "node_modules/rollup-plugin-svelte": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-7.2.0.tgz",
-      "integrity": "sha512-Qvo5VNFQZtaI+sHSjcCIFDP+olfKVyslAoJIkL3DxuhUpNY5Ys0+hhxUY3kuEKt9BXFgkFJiiic/XRb07zdSbg==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-svelte/-/rollup-plugin-svelte-7.2.1.tgz",
+      "integrity": "sha512-I5p+eZXNKzIjGLdWBgpP2bxoqKpsUfttcLM9hoBx6IGX99NdVlWuU8VE81bTrcK9LzHUUF1k2QXWI8tjeKJRAA==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "reconnecting-websocket": "^4.4.0",
         "sirv-cli": "^2.0.2",
         "stats.js": "^0.17.0",
-        "three": "^0.164.1"
+        "three": "^0.165.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.19.1",
@@ -5672,9 +5672,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.164.1",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.164.1.tgz",
-      "integrity": "sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w=="
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA=="
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "mathplayground",
       "version": "1.0.0",
       "dependencies": {
+        "@sveltestrap/sveltestrap": "^6.2.7",
         "mathjs": "^13.0.0",
         "reconnecting-websocket": "^4.4.0",
         "sirv-cli": "^2.0.2",
         "stats.js": "^0.17.0",
-        "sveltestrap": "^5.9.0",
         "three": "^0.164.1"
       },
       "devDependencies": {
@@ -24,12 +24,12 @@
         "@typescript-eslint/types": "^7.0.1",
         "d3": "^7.7.0",
         "eslint": "^9.1.0",
-        "eslint-plugin-svelte": "^2.13.0",
+        "eslint-plugin-svelte": "^2.30.0",
         "mocha": "^10.0.0",
         "rollup": "^4.2.0",
         "rollup-plugin-css-only": "^4.3.0",
-        "rollup-plugin-svelte": "^7.1.0",
-        "svelte": "~3.59.1"
+        "rollup-plugin-svelte": "^7.1.5",
+        "svelte": "^4.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -45,8 +45,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
       "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -1898,7 +1896,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1912,7 +1909,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1921,7 +1917,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1939,14 +1934,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
       "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2303,11 +2296,21 @@
         "win32"
       ]
     },
+    "node_modules/@sveltestrap/sveltestrap": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/@sveltestrap/sveltestrap/-/sveltestrap-6.2.7.tgz",
+      "integrity": "sha512-WwLLfAFUb42BGuRrf3Vbct30bQMzlEMMipN/MfxhjuLTmLQeW9muVJfPyvjtWS+mY+RjkSCoHvAp/ZobP1NLlQ==",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0 || ^5.0.0-next.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -2332,7 +2335,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2413,6 +2415,22 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
+      "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.10",
@@ -2665,6 +2683,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/code-red": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.10.0",
+        "estree-walker": "^3.0.3",
+        "periscopic": "^3.1.0"
+      }
+    },
+    "node_modules/code-red/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2753,6 +2791,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
     "node_modules/cssesc": {
@@ -3224,6 +3274,14 @@
       "dev": true,
       "dependencies": {
         "robust-predicates": "^3.0.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/diff": {
@@ -4263,6 +4321,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4389,7 +4452,6 @@
       "version": "0.30.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
       "integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
       },
@@ -4440,6 +4502,11 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -4721,6 +4788,32 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/periscopic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^3.0.0",
+        "is-reference": "^3.0.0"
+      }
+    },
+    "node_modules/periscopic/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/periscopic/node_modules/is-reference": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -5400,7 +5493,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
       "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5483,11 +5575,27 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.59.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.59.2.tgz",
-      "integrity": "sha512-vzSyuGr3eEoAtT/A6bmajosJZIUWySzY2CzB3w2pgPvnkUjGqlDnsNnA0PMO+mMAhuyMul6C2uuZzY6ELSkzyA==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
+      "integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/estree": "^1.0.1",
+        "acorn": "^8.9.0",
+        "aria-query": "^5.3.0",
+        "axobject-query": "^4.0.0",
+        "code-red": "^1.0.3",
+        "css-tree": "^2.3.1",
+        "estree-walker": "^3.0.3",
+        "is-reference": "^3.0.1",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.4",
+        "periscopic": "^3.1.0"
+      },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16"
       }
     },
     "node_modules/svelte-eslint-parser": {
@@ -5517,15 +5625,20 @@
         }
       }
     },
-    "node_modules/sveltestrap": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/sveltestrap/-/sveltestrap-5.11.3.tgz",
-      "integrity": "sha512-R7vIyzqaXT8dKUytZRrU1sPdhinglRXJb43LKfGcR9Tc+71icg3onhniJARbokCkICiGxpgbgKNQRS3gGyQNXw==",
+    "node_modules/svelte/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dependencies": {
-        "@popperjs/core": "^2.11.8"
-      },
-      "peerDependencies": {
-        "svelte": "^3.53.1"
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/svelte/node_modules/is-reference": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "reconnecting-websocket": "^4.4.0",
     "sirv-cli": "^2.0.2",
     "stats.js": "^0.17.0",
-    "three": "^0.164.1"
+    "three": "^0.165.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
     "@typescript-eslint/types": "^7.0.1",
     "d3": "^7.7.0",
     "eslint": "^9.1.0",
-    "eslint-plugin-svelte": "^2.13.0",
+    "eslint-plugin-svelte": "^2.30.0",
     "mocha": "^10.0.0",
     "rollup": "^4.2.0",
     "rollup-plugin-css-only": "^4.3.0",
-    "rollup-plugin-svelte": "^7.1.0",
-    "svelte": "~3.59.1"
+    "rollup-plugin-svelte": "^7.1.5",
+    "svelte": "^4.0.0"
   },
   "dependencies": {
+    "@sveltestrap/sveltestrap": "^6.2.7",
     "mathjs": "^13.0.0",
     "reconnecting-websocket": "^4.4.0",
     "sirv-cli": "^2.0.2",
     "stats.js": "^0.17.0",
-    "sveltestrap": "^5.9.0",
     "three": "^0.164.1"
   }
 }


### PR DESCRIPTION
Migration to Svelte 4. [Migration script](https://svelte.dev/docs/v4-migration-guide) went through pretty cleanly. 
Moved from `@bestguy/sveltestrap` (required 3, not maintained) to [`@sveltestrap/sveltestrap`](https://github.com/sveltestrap/sveltestrap). 
Seems alright. Could need another check on "strappy" components. 