### PR TITLE
Run effect only on clock change

### DIFF
--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -615,15 +615,19 @@
     $effect(() => {
         if (animation) untrack(animate);
     });
-    $effect(() => {
+    function currentTock() {
         if (animation) {
             const currentTime = $tickTock;
+
             last = last || currentTime;
             update(currentTime - last);
             last = currentTime;
         } else {
             last = null;
         }
+    }
+    $effect(() => {
+        if ($tickTock) untrack(currentTock);
     });
 
     let lastLevelTime = null;


### PR DESCRIPTION
`$effect` rune runs too frequently because of other state changes. Only want to run once per frame. We untrack the other side effects. 

(Generally, there is too much `$effect`/`untrack` in here. Will look into refactoring later. Though triggered from multiple sources, it may not need to be reactive in this way. 