### PR TITLE
Catch bound error

### DIFF
--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -803,7 +803,7 @@
             ];
         } catch (e) {
             console.error("Can't show integral boxes on nonconstant bounds",e);
-            return
+            return;
         }
 
         const [A, B, C, D] = [

--- a/media/src/objects/Function.svelte
+++ b/media/src/objects/Function.svelte
@@ -793,16 +793,28 @@
     boxMesh.add(boxMeshEdges);
 
     const updateBoxes = function () {
-        const { a, b, c, d, t0, t1 } = params;
-        const [A, B, C, D, T0, T1] = [
-            math.evaluate(a),
-            math.evaluate(b),
-            math.evaluate(c),
-            math.evaluate(d),
-            math.evaluate(t0),
-            math.evaluate(t1),
-        ];
-        const t = T0 + tau * (T1 - T0);
+        const { a, b, c, d} = params;
+        try {
+         [
+                math.evaluate(a),
+                math.evaluate(b),
+                math.evaluate(c),
+                math.evaluate(d),
+            ];
+        } catch (e) {
+            console.error("Can't show integral boxes on nonconstant bounds",e);
+            return
+        }
+
+        const [A, B, C, D] = [
+                math.evaluate(a),
+                math.evaluate(b),
+                math.evaluate(c),
+                math.evaluate(d),
+            ];
+
+
+        // const t = T0 + tau * (T1 - T0);
 
         if (boxMesh.geometry) {
             boxMesh.geometry.dispose();
@@ -810,7 +822,7 @@
         }
         boxMesh.geometry = blockGeometry(
             (x, y) => {
-                return func(x, y, t);
+                return func(x, y, tVal);
             },
             A,
             B,

--- a/media/src/utils.js
+++ b/media/src/utils.js
@@ -1582,10 +1582,21 @@ class ParametricGeometry extends THREE.BufferGeometry {
     }
 }
 
+/**
+ * return a geometry of an approximation of f on the rectangle [a,b] \times [c,d]
+       using M\times N subrectangles and sampling at (s,t) (relative coords) in each.
+ * @param {function(x: number, y:number): number} f integrand f(x,y)
+ * @param {number} a lower x bound
+ * @param {number} b upper x bound
+ * @param {number} c lower y bound
+ * @param {number} d upper y bound 
+ * @param {number} M number of x subdivisions 
+ * @param {number} N number of y subdivisions 
+ * @param {number} s proportion for x sample point
+ * @param {number} t proportion for y sample point
+ * @returns BufferGeometry
+ */
 function blockGeometry(f, a, b, c, d, M = 5, N = 5, s = 0.5, t = 0.5) {
-    /* return a geometry of an approximation of f on the rectangle [a,b] \times [c,d]
-       using M\times N subrectangles and sampling at (s,t) (relative coords) in each.*/
-
     let points = [];
     let colors = [];
     let normals = [];


### PR DESCRIPTION
Addresses #1172 by simply catching the error of nonconstant bounds and exiting. We should actually handle these properly in a Story, but that is for another day.
