### PR TITLE
Revert "Update boto3 requirement from <1.36.0,>=1.20.0 to >=1.20.0,<1.38.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ attrs==25.3.0
 autobahn==24.4.2
 Automat==25.4.16
 backports.zoneinfo;python_version<"3.9"
-boto3>=1.20.0,<1.38.0
+boto3>=1.20.0,<1.36.0
 botocore>=1.25.0,<1.37.0
 certifi==2025.1.31
 cffi==1.17.0


### PR DESCRIPTION
Reverts ccnmtl/3demos#1313

Jenkins is failing in the `collectstatic` step. There's a mismatch in parameter outcomes in the interaction between `staticfiles`, `storages`, and `boto3`. There were two updates at the time of failure. This one and and update to `automat`. Given the errors in the Console Output this is the likely first candidate.